### PR TITLE
feat: トレイメニューに「最新10件を確認」を追加

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -140,6 +140,65 @@ function createSettingsWindow(): void {
   });
 }
 
+async function handleFetchLatest(): Promise<void> {
+  if (!monitor) {
+    await dialog.showMessageBox({
+      type: 'info',
+      title: '最新10件を確認',
+      message: 'モニターが初期化されていません。',
+      buttons: ['OK'],
+    });
+    return;
+  }
+
+  try {
+    const records = await monitor.fetchLatest(10);
+
+    if (records.length === 0) {
+      await dialog.showMessageBox({
+        type: 'info',
+        title: '最新10件を確認',
+        message: '通知が見つかりませんでした。',
+        detail: 'データベースに通知が存在しないか、まだ記録されていません。',
+        buttons: ['閉じる'],
+      });
+      return;
+    }
+
+    const lines = records.map((r, i) => {
+      const num = String(i + 1).padStart(2, ' ');
+      const senderPart = r.sender !== r.appName ? ` - ${r.sender}` : '';
+      return `${num}. [${r.timestamp}] ${r.appName}${senderPart}\n    ${r.body}\n    (ID: ${r.id}, ${r.rawId})`;
+    });
+
+    await dialog.showMessageBox({
+      type: 'info',
+      title: `最新${records.length}件の通知`,
+      message: `データベースから取得した最新${records.length}件（新しい順）`,
+      detail: lines.join('\n\n'),
+      buttons: ['閉じる'],
+    });
+  } catch (err) {
+    const message = (err as Error).message ?? '';
+    const isPermission =
+      message.includes('SQLITE_CANTOPEN') ||
+      message.includes('unable to open database') ||
+      message.includes('ENOENT') ||
+      message.includes('EACCES') ||
+      message.includes('directory does not exist');
+
+    await dialog.showMessageBox({
+      type: 'warning',
+      title: '最新10件を確認 - エラー',
+      message: isPermission
+        ? 'データベースにアクセスできませんでした。'
+        : '通知の取得中にエラーが発生しました。',
+      detail: isPermission ? 'フルディスクアクセス権限が必要な場合があります。' : message,
+      buttons: ['OK'],
+    });
+  }
+}
+
 function createTray(): void {
   const iconFile = process.platform === 'win32' ? 'icon-win.png' : 'iconTemplate.png';
   const icon = nativeImage.createFromPath(path.join(__dirname, '../../resources', iconFile));
@@ -158,6 +217,12 @@ function createTray(): void {
           body: 'これはテスト通知です！',
           appName: 'Mascot Notifier',
         });
+      },
+    },
+    {
+      label: '最新10件を確認',
+      click: () => {
+        void handleFetchLatest();
       },
     },
     { type: 'separator' },

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -179,12 +179,13 @@ async function handleFetchLatest(): Promise<void> {
       buttons: ['閉じる'],
     });
   } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code ?? '';
     const message = (err as Error).message ?? '';
     const isPermission =
-      message.includes('SQLITE_CANTOPEN') ||
+      code === 'ENOENT' ||
+      code === 'EACCES' ||
+      code === 'SQLITE_CANTOPEN' ||
       message.includes('unable to open database') ||
-      message.includes('ENOENT') ||
-      message.includes('EACCES') ||
       message.includes('directory does not exist');
 
     await dialog.showMessageBox({

--- a/src/main/monitors/base.ts
+++ b/src/main/monitors/base.ts
@@ -6,6 +6,26 @@ export interface NotificationData {
   appName?: string;
 }
 
+export interface LatestNotificationRecord {
+  id: number;
+  timestamp: string;
+  sender: string;
+  body: string;
+  appName: string;
+  rawId: string;
+}
+
+export function formatNotificationTimestamp(unixMs: number): string {
+  return new Date(unixMs).toLocaleString('ja-JP', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+  });
+}
+
 /**
  * Base class for platform-specific notification monitors.
  *
@@ -23,6 +43,7 @@ export abstract class BaseNotificationMonitor extends EventEmitter {
   protected seenIds = new Set<number>();
 
   protected abstract poll(): Promise<void>;
+  abstract fetchLatest(n: number): Promise<LatestNotificationRecord[]>;
 
   start(): void {
     if (this.intervalId) return;

--- a/src/main/monitors/mac.ts
+++ b/src/main/monitors/mac.ts
@@ -88,10 +88,13 @@ export class MacNotificationMonitor extends BaseNotificationMonitor {
 
       this.trimSeenCache();
     } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code ?? '';
       const message = (err as Error).message;
       console.error('MacNotificationMonitor poll error:', message);
       if (
-        message.includes('SQLITE_CANTOPEN') ||
+        code === 'ENOENT' ||
+        code === 'EACCES' ||
+        code === 'SQLITE_CANTOPEN' ||
         message.includes('unable to open database') ||
         message.includes('directory does not exist')
       ) {
@@ -104,15 +107,19 @@ export class MacNotificationMonitor extends BaseNotificationMonitor {
     const dbPath = this.dbPath ?? MacNotificationMonitor.resolveDbPath();
 
     const db = new Database(dbPath, { readonly: true, fileMustExist: true });
-    const rows = db
-      .prepare(`
-        SELECT rec.rec_id, rec.data, rec.delivered_date
-        FROM record AS rec
-        ORDER BY rec.delivered_date DESC
-        LIMIT ?
-      `)
-      .all(n) as Array<{ rec_id: number; data: Buffer; delivered_date: number }>;
-    db.close();
+    let rows: Array<{ rec_id: number; data: Buffer; delivered_date: number }>;
+    try {
+      rows = db
+        .prepare(`
+          SELECT rec.rec_id, rec.data, rec.delivered_date
+          FROM record AS rec
+          ORDER BY rec.delivered_date DESC
+          LIMIT ?
+        `)
+        .all(n) as typeof rows;
+    } finally {
+      db.close();
+    }
 
     return await Promise.all(
       rows.map(async (row) => {

--- a/src/main/monitors/mac.ts
+++ b/src/main/monitors/mac.ts
@@ -2,7 +2,11 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { resolveAppName } from '../appNameResolver';
-import { BaseNotificationMonitor } from './base';
+import {
+  BaseNotificationMonitor,
+  formatNotificationTimestamp,
+  type LatestNotificationRecord,
+} from './base';
 
 // eslint-disable-next-line no-eval
 const nativeRequire = eval('require') as NodeRequire;
@@ -10,10 +14,12 @@ const Database = nativeRequire('better-sqlite3') as typeof import('better-sqlite
 const bplist = nativeRequire('bplist-parser') as { parseBuffer: (buf: Buffer) => unknown[] };
 
 export class MacNotificationMonitor extends BaseNotificationMonitor {
+  private static readonly CORE_DATA_EPOCH_OFFSET = 978307200;
+
   private lastCheckTime: number = Date.now();
   private dbPath: string | null = null;
 
-  protected onStart(): void {
+  private static resolveDbPath(): string {
     const newPath = path.join(
       os.homedir(),
       'Library/Group Containers/group.com.apple.usernoted/db2/db',
@@ -22,7 +28,11 @@ export class MacNotificationMonitor extends BaseNotificationMonitor {
       os.homedir(),
       'Library/Application Support/com.apple.notificationcenter/db2/db',
     );
-    this.dbPath = fs.existsSync(newPath) ? newPath : legacyPath;
+    return fs.existsSync(newPath) ? newPath : legacyPath;
+  }
+
+  protected onStart(): void {
+    this.dbPath = MacNotificationMonitor.resolveDbPath();
     this.lastCheckTime = Date.now();
     console.log('MacNotificationMonitor started, DB:', this.dbPath);
   }
@@ -37,8 +47,7 @@ export class MacNotificationMonitor extends BaseNotificationMonitor {
     try {
       const db = new Database(this.dbPath, { readonly: true, fileMustExist: true });
 
-      // Core Data epoch: 2001-01-01 is 978307200 seconds after Unix epoch
-      const since = this.lastCheckTime / 1000 - 978307200;
+      const since = this.lastCheckTime / 1000 - MacNotificationMonitor.CORE_DATA_EPOCH_OFFSET;
       const rows = db
         .prepare(`
           SELECT rec.rec_id, rec.data, rec.delivered_date
@@ -73,7 +82,8 @@ export class MacNotificationMonitor extends BaseNotificationMonitor {
 
       if (rows.length > 0) {
         const lastRow = rows[rows.length - 1];
-        this.lastCheckTime = (lastRow.delivered_date + 978307200) * 1000;
+        this.lastCheckTime =
+          (lastRow.delivered_date + MacNotificationMonitor.CORE_DATA_EPOCH_OFFSET) * 1000;
       }
 
       this.trimSeenCache();
@@ -88,6 +98,61 @@ export class MacNotificationMonitor extends BaseNotificationMonitor {
         this.emitPermissionErrorOnce();
       }
     }
+  }
+
+  async fetchLatest(n: number): Promise<LatestNotificationRecord[]> {
+    const dbPath = this.dbPath ?? MacNotificationMonitor.resolveDbPath();
+
+    const db = new Database(dbPath, { readonly: true, fileMustExist: true });
+    const rows = db
+      .prepare(`
+        SELECT rec.rec_id, rec.data, rec.delivered_date
+        FROM record AS rec
+        ORDER BY rec.delivered_date DESC
+        LIMIT ?
+      `)
+      .all(n) as Array<{ rec_id: number; data: Buffer; delivered_date: number }>;
+    db.close();
+
+    return await Promise.all(
+      rows.map(async (row) => {
+        const timestamp = formatNotificationTimestamp(
+          (row.delivered_date + MacNotificationMonitor.CORE_DATA_EPOCH_OFFSET) * 1000,
+        );
+
+        const p = this.parseNotificationData(row.data);
+        if (p !== null) {
+          const appName = await resolveAppName(p.bundleId);
+          return {
+            id: row.rec_id,
+            timestamp,
+            sender: p.sender,
+            body: p.body,
+            appName,
+            rawId: p.bundleId,
+          };
+        }
+
+        let bundleId = '';
+        try {
+          const raw = bplist.parseBuffer(row.data);
+          if (raw?.[0]) {
+            const root = raw[0] as Record<string, unknown>;
+            bundleId = typeof root.app === 'string' ? root.app : '';
+          }
+        } catch {
+          // ignore
+        }
+        return {
+          id: row.rec_id,
+          timestamp,
+          sender: '(不明)',
+          body: '(パース失敗)',
+          appName: bundleId || '(不明)',
+          rawId: bundleId,
+        };
+      }),
+    );
   }
 
   private parseNotificationData(

--- a/src/main/monitors/windows.ts
+++ b/src/main/monitors/windows.ts
@@ -1,7 +1,11 @@
 import os from 'node:os';
 import path from 'node:path';
 import { resolveAppName } from '../appNameResolver';
-import { BaseNotificationMonitor } from './base';
+import {
+  BaseNotificationMonitor,
+  formatNotificationTimestamp,
+  type LatestNotificationRecord,
+} from './base';
 
 // eslint-disable-next-line no-eval
 const nativeRequire = eval('require') as NodeRequire;
@@ -109,6 +113,66 @@ export class WindowsNotificationMonitor extends BaseNotificationMonitor {
         this.emitPermissionErrorOnce();
       }
     }
+  }
+
+  async fetchLatest(n: number): Promise<LatestNotificationRecord[]> {
+    const dbPath =
+      this.dbPath ||
+      path.join(
+        os.homedir(),
+        'AppData',
+        'Local',
+        'Microsoft',
+        'Windows',
+        'Notifications',
+        'wpndatabase.db',
+      );
+
+    const db = new Database(dbPath, { readonly: true, fileMustExist: true });
+    const rows = db
+      .prepare(`
+        SELECT n.Id, n.ArrivalTime, n.Payload, h.PrimaryId
+        FROM Notification n
+        LEFT JOIN NotificationHandler h ON n.HandlerId = h.RecordId
+        WHERE n.Type = 'toast'
+        ORDER BY n.ArrivalTime DESC
+        LIMIT ?
+      `)
+      .all(n) as Array<{
+      Id: number;
+      ArrivalTime: number;
+      Payload: Buffer | string;
+      PrimaryId: string | null;
+    }>;
+    db.close();
+
+    return await Promise.all(
+      rows.map(async (row) => {
+        const unixSeconds =
+          row.ArrivalTime / WindowsNotificationMonitor.FILETIME_TICKS_PER_SECOND -
+          WindowsNotificationMonitor.FILETIME_UNIX_EPOCH_OFFSET;
+        const timestamp = formatNotificationTimestamp(unixSeconds * 1000);
+
+        const payload = Buffer.isBuffer(row.Payload)
+          ? row.Payload.toString('utf-8')
+          : String(row.Payload);
+        const p = this.parsePayload(payload, row.PrimaryId);
+        if (p !== null) {
+          const appName = await resolveAppName(p.appId);
+          return { id: row.Id, timestamp, sender: p.sender, body: p.body, appName, rawId: p.appId };
+        }
+
+        const appId = row.PrimaryId ?? '';
+        return {
+          id: row.Id,
+          timestamp,
+          sender: '(不明)',
+          body: '(パース失敗)',
+          appName: appId || '(不明)',
+          rawId: appId,
+        };
+      }),
+    );
   }
 
   private parsePayload(

--- a/src/main/monitors/windows.ts
+++ b/src/main/monitors/windows.ts
@@ -129,22 +129,26 @@ export class WindowsNotificationMonitor extends BaseNotificationMonitor {
       );
 
     const db = new Database(dbPath, { readonly: true, fileMustExist: true });
-    const rows = db
-      .prepare(`
-        SELECT n.Id, n.ArrivalTime, n.Payload, h.PrimaryId
-        FROM Notification n
-        LEFT JOIN NotificationHandler h ON n.HandlerId = h.RecordId
-        WHERE n.Type = 'toast'
-        ORDER BY n.ArrivalTime DESC
-        LIMIT ?
-      `)
-      .all(n) as Array<{
+    let rows: Array<{
       Id: number;
       ArrivalTime: number;
       Payload: Buffer | string;
       PrimaryId: string | null;
     }>;
-    db.close();
+    try {
+      rows = db
+        .prepare(`
+          SELECT n.Id, n.ArrivalTime, n.Payload, h.PrimaryId
+          FROM Notification n
+          LEFT JOIN NotificationHandler h ON n.HandlerId = h.RecordId
+          WHERE n.Type = 'toast'
+          ORDER BY n.ArrivalTime DESC
+          LIMIT ?
+        `)
+        .all(n) as typeof rows;
+    } finally {
+      db.close();
+    }
 
     return await Promise.all(
       rows.map(async (row) => {

--- a/src/main/notificationMonitor.ts
+++ b/src/main/notificationMonitor.ts
@@ -2,7 +2,7 @@ import type { BaseNotificationMonitor } from './monitors/base';
 import { MacNotificationMonitor } from './monitors/mac';
 import { WindowsNotificationMonitor } from './monitors/windows';
 
-export type { NotificationData } from './monitors/base';
+export type { LatestNotificationRecord, NotificationData } from './monitors/base';
 export type { BaseNotificationMonitor };
 
 export function createNotificationMonitor(): BaseNotificationMonitor {


### PR DESCRIPTION
通知が取得できない原因調査のため、通知DBの最新10件を
ダイアログ表示するメニュー項目を「テスト通知」の直下に追加。
パース失敗行も bundleId/PrimaryId を表示してデバッグを支援する。