### PR TITLE
test: Vitestによる単体テスト基盤を導入

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,9 @@
       "version": "0.1.0",
       "hasInstallScript": true,
       "dependencies": {
+        "better-sqlite3": "^11.7.0",
         "bplist-parser": "^0.3.2",
-        "lottie-react": "^2.4.1",
-        "sql.js": "^1.14.1"
+        "lottie-react": "^2.4.1"
       },
       "devDependencies": {
         "@biomejs/biome": "2.4.10",
@@ -28,10 +28,8 @@
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "typescript": "^5.7.0",
-        "vite": "^6.0.0"
-      },
-      "optionalDependencies": {
-        "better-sqlite3": "^11.7.0"
+        "vite": "^6.0.0",
+        "vitest": "^4.1.4"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2525,6 +2523,13 @@
         "url": "https://github.com/sindresorhus/is?sponsor=1"
       }
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@szmarczak/http-timer": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
@@ -2616,6 +2621,17 @@
         "@types/responselike": "^1.0.0"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/debug": {
       "version": "4.1.13",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
@@ -2625,6 +2641,13 @@
       "dependencies": {
         "@types/ms": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -2758,6 +2781,119 @@
       },
       "peerDependencies": {
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.4.tgz",
+      "integrity": "sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.4",
+        "@vitest/utils": "4.1.4",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.4.tgz",
+      "integrity": "sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.4.tgz",
+      "integrity": "sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.4.tgz",
+      "integrity": "sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.4",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.4.tgz",
+      "integrity": "sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.4",
+        "@vitest/utils": "4.1.4",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.4.tgz",
+      "integrity": "sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.4.tgz",
+      "integrity": "sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.4",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@xmldom/xmldom": {
@@ -3216,6 +3352,16 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/astral-regex": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
@@ -3272,7 +3418,6 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -3308,7 +3453,6 @@
       "integrity": "sha512-EwhOpyXiOEL/lKzHz9AW1msWFNzGc/z+LzeB3/jnFJpxu+th2yqvzsSWas1v9jgs9+xiXJcD5A8CJxAG2TaghQ==",
       "hasInstallScript": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "bindings": "^1.5.0",
         "prebuild-install": "^7.1.1"
@@ -3328,7 +3472,6 @@
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
       "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "file-uri-to-path": "1.0.0"
       }
@@ -3337,7 +3480,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
       "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "buffer": "^5.5.0",
@@ -3416,7 +3558,6 @@
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
       "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -3727,6 +3868,16 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -4024,7 +4175,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
       "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "mimic-response": "^3.1.0"
@@ -4040,7 +4190,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
       "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -4054,7 +4203,6 @@
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
       "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=4.0.0"
       }
@@ -4141,7 +4289,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "devOptional": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -4661,7 +4808,6 @@
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
       "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
@@ -4703,6 +4849,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
@@ -4807,14 +4960,33 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/expand-template": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
       "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
       "license": "(MIT OR WTFPL)",
-      "optional": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/exponential-backoff": {
@@ -4902,8 +5074,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
       "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/filelist": {
       "version": "1.0.6",
@@ -4989,8 +5160,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/fs-extra": {
       "version": "8.1.0",
@@ -5152,8 +5322,7 @@
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
       "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/glob": {
       "version": "7.2.3",
@@ -5483,7 +5652,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -5543,15 +5711,13 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/ini": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/ip-address": {
       "version": "10.1.0",
@@ -5989,7 +6155,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "devOptional": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -6123,8 +6288,7 @@
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -6156,8 +6320,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
       "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/negotiator": {
       "version": "0.6.4",
@@ -6173,7 +6336,6 @@
       "version": "3.89.0",
       "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.89.0.tgz",
       "integrity": "sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "semver": "^7.3.5"
@@ -6186,7 +6348,6 @@
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "devOptional": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -6340,11 +6501,21 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -6493,6 +6664,13 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/pe-library": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/pe-library/-/pe-library-0.4.1.tgz",
@@ -6614,7 +6792,6 @@
       "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
       "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "detect-libc": "^2.0.0",
         "expand-template": "^2.0.3",
@@ -6693,7 +6870,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
       "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "end-of-stream": "^1.1.0",
@@ -6728,7 +6904,6 @@
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
       "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
       "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
-      "optional": true,
       "dependencies": {
         "deep-extend": "^0.6.0",
         "ini": "~1.3.0",
@@ -6789,7 +6964,6 @@
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.3",
@@ -6957,7 +7131,6 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -7072,6 +7245,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
@@ -7097,8 +7277,7 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/simple-get": {
       "version": "4.0.1",
@@ -7119,7 +7298,6 @@
         }
       ],
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "decompress-response": "^6.0.0",
         "once": "^1.3.1",
@@ -7248,12 +7426,6 @@
       "license": "BSD-3-Clause",
       "optional": true
     },
-    "node_modules/sql.js": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/sql.js/-/sql.js-1.14.1.tgz",
-      "integrity": "sha512-gcj8zBWU5cFsi9WUP+4bFNXAyF1iRpA3LLyS/DP5xlrNzGmPIizUeBggKa8DbDwdqaKwUcTEnChtd2grWo/x/A==",
-      "license": "MIT"
-    },
     "node_modules/ssri": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/ssri/-/ssri-9.0.1.tgz",
@@ -7267,6 +7439,13 @@
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/stat-mode": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/stat-mode/-/stat-mode-1.0.0.tgz",
@@ -7277,11 +7456,17 @@
         "node": ">= 6"
       }
     },
+    "node_modules/std-env": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.0.0.tgz",
+      "integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
@@ -7350,7 +7535,6 @@
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
       "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7405,7 +7589,6 @@
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
       "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "chownr": "^1.1.1",
         "mkdirp-classic": "^0.5.2",
@@ -7417,15 +7600,13 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
       "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/tar-stream": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
       "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "bl": "^4.0.3",
         "end-of-stream": "^1.4.1",
@@ -7564,6 +7745,23 @@
         "semver": "bin/semver"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
+      "integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -7579,6 +7777,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/tmp": {
@@ -7616,7 +7824,6 @@
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "safe-buffer": "^5.0.1"
       },
@@ -7747,7 +7954,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/verror": {
@@ -7842,6 +8048,96 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.4.tgz",
+      "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.4",
+        "@vitest/mocker": "4.1.4",
+        "@vitest/pretty-format": "4.1.4",
+        "@vitest/runner": "4.1.4",
+        "@vitest/snapshot": "4.1.4",
+        "@vitest/spy": "4.1.4",
+        "@vitest/utils": "4.1.4",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.4",
+        "@vitest/browser-preview": "4.1.4",
+        "@vitest/browser-webdriverio": "4.1.4",
+        "@vitest/coverage-istanbul": "4.1.4",
+        "@vitest/coverage-v8": "4.1.4",
+        "@vitest/ui": "4.1.4",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/wcwidth": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
@@ -7866,6 +8162,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/wide-align": {
@@ -7919,7 +8232,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/xmlbuilder": {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.1.0",
   "description": "Desktop mascot notification app",
   "main": "./out/main/index.js",
+  "engines": {
+    "node": ">=20"
+  },
   "scripts": {
     "dev": "electron-vite dev",
     "build": "electron-vite build",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "build": "electron-vite build",
     "preview": "electron-vite preview",
     "postinstall": "electron-rebuild -f -w better-sqlite3",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "lint": "biome check src/",
     "lint:fix": "biome check --write src/",
     "format": "biome format --write src/",
@@ -69,6 +71,7 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "typescript": "^5.7.0",
-    "vite": "^6.0.0"
+    "vite": "^6.0.0",
+    "vitest": "^4.1.4"
   }
 }

--- a/src/main/appNameResolver.test.ts
+++ b/src/main/appNameResolver.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest';
+import { BoundedCache, fallbackName, normalizeWinId, resolveAppNameWin } from './appNameResolver';
+
+describe('BoundedCache', () => {
+  it('stores and retrieves values', () => {
+    const c = new BoundedCache(3);
+    c.set('a', '1');
+    expect(c.get('a')).toBe('1');
+  });
+
+  it('evicts the oldest entry once capacity is exceeded', () => {
+    const c = new BoundedCache(3);
+    c.set('a', '1');
+    c.set('b', '2');
+    c.set('c', '3');
+    c.set('d', '4'); // should evict 'a'
+    expect(c.has('a')).toBe(false);
+    expect(c.get('b')).toBe('2');
+    expect(c.get('c')).toBe('3');
+    expect(c.get('d')).toBe('4');
+  });
+
+  it('marks an entry as most-recent on get so it survives eviction', () => {
+    const c = new BoundedCache(3);
+    c.set('a', '1');
+    c.set('b', '2');
+    c.set('c', '3');
+    // Touch 'a' so it becomes most recent
+    c.get('a');
+    c.set('d', '4'); // should now evict 'b' instead of 'a'
+    expect(c.has('a')).toBe(true);
+    expect(c.has('b')).toBe(false);
+  });
+
+  it('re-setting an existing key updates recency', () => {
+    const c = new BoundedCache(2);
+    c.set('a', '1');
+    c.set('b', '2');
+    c.set('a', '11'); // refresh 'a'
+    c.set('c', '3'); // should evict 'b'
+    expect(c.get('a')).toBe('11');
+    expect(c.has('b')).toBe(false);
+    expect(c.get('c')).toBe('3');
+  });
+});
+
+describe('fallbackName', () => {
+  it('returns the last dot-separated segment', () => {
+    expect(fallbackName('com.tinyspeck.slackmacgap')).toBe('slackmacgap');
+  });
+
+  it('returns the identifier itself when there is no dot', () => {
+    expect(fallbackName('Slack')).toBe('Slack');
+  });
+
+  it('returns the input string when it ends with an empty segment', () => {
+    expect(fallbackName('com.example.')).toBe('com.example.');
+  });
+});
+
+describe('normalizeWinId', () => {
+  it('strips the "!" suffix and _hash', () => {
+    expect(normalizeWinId('Microsoft.Teams2_8wekyb3d8bbwe!MSTeams')).toBe('Microsoft.Teams2');
+  });
+
+  it('returns the id unchanged when it has no "!" or "_"', () => {
+    expect(normalizeWinId('Microsoft.WindowsStore')).toBe('Microsoft.WindowsStore');
+  });
+
+  it('strips _hash even without "!"', () => {
+    expect(normalizeWinId('Microsoft.Teams_abc')).toBe('Microsoft.Teams');
+  });
+});
+
+describe('resolveAppNameWin', () => {
+  it('returns the known PWA host name when appId is a URL after "!"', () => {
+    expect(resolveAppNameWin('SomePrefix!https://chat.google.com/messages')).toBe('Google Chat');
+  });
+
+  it('returns the second-level domain when host is not a known PWA', () => {
+    expect(resolveAppNameWin('SomePrefix!https://example.co.jp/foo')).toBe('co');
+    // Note: the function takes parts.length - 2, so for example.com it returns "example"
+    expect(resolveAppNameWin('SomePrefix!https://example.com/foo')).toBe('example');
+  });
+
+  it('falls back to descriptive segment for package-style ids', () => {
+    // "stable" is non-descriptive, so should pick the next meaningful segment
+    expect(resolveAppNameWin('com.example.MyApp.stable')).toBe('MyApp');
+  });
+
+  it('skips known non-descriptive segments', () => {
+    expect(resolveAppNameWin('com.google.Chrome.beta')).toBe('Chrome');
+    expect(resolveAppNameWin('foo.bar.Baz.app')).toBe('Baz');
+  });
+
+  it('strips _hash from the picked segment', () => {
+    expect(resolveAppNameWin('Microsoft.Teams2_8wekyb3d8bbwe')).toBe('Teams2');
+  });
+
+  it('returns the appId itself when nothing descriptive is found', () => {
+    expect(resolveAppNameWin('app')).toBe('app');
+  });
+
+  it('handles a malformed URL after "!" by falling back to segment parsing', () => {
+    // URL parsing will throw, so falls through to segment logic on the part before "!"
+    expect(resolveAppNameWin('Microsoft.Teams!not a url')).toBe('Teams');
+  });
+});

--- a/src/main/appNameResolver.ts
+++ b/src/main/appNameResolver.ts
@@ -3,7 +3,7 @@ import { promisify } from 'node:util';
 
 const execFileAsync = promisify(execFile);
 
-class BoundedCache extends Map<string, string> {
+export class BoundedCache extends Map<string, string> {
   constructor(private readonly maxEntries: number) {
     super();
   }
@@ -105,7 +105,7 @@ const KNOWN_PWA_HOSTS: Record<string, string> = {
   'x.com': 'X',
 };
 
-function resolveAppNameWin(appId: string): string {
+export function resolveAppNameWin(appId: string): string {
   const exclamationIdx = appId.indexOf('!');
   if (exclamationIdx !== -1) {
     const afterExcl = appId.slice(exclamationIdx + 1);
@@ -133,12 +133,12 @@ function resolveAppNameWin(appId: string): string {
   return parts[0]?.replace(/_.*$/, '') || appId;
 }
 
-function fallbackName(identifier: string): string {
+export function fallbackName(identifier: string): string {
   const parts = identifier.split('.');
   return parts[parts.length - 1] || identifier;
 }
 
-function normalizeWinId(appId: string): string {
+export function normalizeWinId(appId: string): string {
   return appId.split('!')[0].replace(/_.*$/, '');
 }
 

--- a/src/main/monitors/base.test.ts
+++ b/src/main/monitors/base.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+import {
+  BaseNotificationMonitor,
+  formatNotificationTimestamp,
+  type LatestNotificationRecord,
+} from './base';
+
+describe('formatNotificationTimestamp', () => {
+  it('zero-pads month, day, hour, minute and second in ja-JP locale', () => {
+    // 2024-01-02 03:04:05 local time
+    const ms = new Date(2024, 0, 2, 3, 4, 5).getTime();
+    const out = formatNotificationTimestamp(ms);
+    // ja-JP returns like "2024/01/02 03:04:05"
+    expect(out).toMatch(/2024[/-]01[/-]02\s+03:04:05/);
+  });
+
+  it('formats a realistic notification time', () => {
+    const ms = new Date(2026, 3, 10, 23, 59, 0).getTime();
+    const out = formatNotificationTimestamp(ms);
+    expect(out).toMatch(/2026[/-]04[/-]10\s+23:59:00/);
+  });
+});
+
+// Test subclass to expose protected internals for unit testing.
+class TestMonitor extends BaseNotificationMonitor {
+  protected async poll(): Promise<void> {}
+  async fetchLatest(_n: number): Promise<LatestNotificationRecord[]> {
+    return [];
+  }
+
+  addSeen(id: number): void {
+    this.seenIds.add(id);
+  }
+
+  seenSize(): number {
+    return this.seenIds.size;
+  }
+
+  hasSeen(id: number): boolean {
+    return this.seenIds.has(id);
+  }
+
+  runTrim(): void {
+    this.trimSeenCache();
+  }
+}
+
+describe('BaseNotificationMonitor.trimSeenCache', () => {
+  it('is a no-op when cache size is at or below 500', () => {
+    const m = new TestMonitor();
+    for (let i = 0; i < 500; i++) m.addSeen(i);
+    m.runTrim();
+    expect(m.seenSize()).toBe(500);
+  });
+
+  it('trims down to 200 when size exceeds 500', () => {
+    const m = new TestMonitor();
+    for (let i = 0; i < 600; i++) m.addSeen(i);
+    m.runTrim();
+    expect(m.seenSize()).toBe(200);
+  });
+
+  it('removes oldest entries first (insertion order)', () => {
+    const m = new TestMonitor();
+    for (let i = 0; i < 600; i++) m.addSeen(i);
+    m.runTrim();
+    // After trimming 600 - 200 = 400 items, the oldest 400 (ids 0..399) should be gone
+    expect(m.hasSeen(0)).toBe(false);
+    expect(m.hasSeen(399)).toBe(false);
+    expect(m.hasSeen(400)).toBe(true);
+    expect(m.hasSeen(599)).toBe(true);
+  });
+});

--- a/src/main/monitors/mac.test.ts
+++ b/src/main/monitors/mac.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import { extractMacNotification } from './macParser';
+
+describe('extractMacNotification', () => {
+  it('returns null when root is nullish', () => {
+    expect(extractMacNotification(null)).toBeNull();
+    expect(extractMacNotification(undefined)).toBeNull();
+  });
+
+  it('returns null when req is missing', () => {
+    expect(extractMacNotification({ app: 'com.example.app' })).toBeNull();
+  });
+
+  it('returns null when body cannot be found', () => {
+    expect(
+      extractMacNotification({
+        app: 'com.example.app',
+        req: { titl: 'Only title, no body' },
+      }),
+    ).toBeNull();
+  });
+
+  it('extracts sender and body from a string body', () => {
+    const result = extractMacNotification({
+      app: 'com.tinyspeck.slackmacgap',
+      req: { titl: 'Alice', body: 'Hello there' },
+    });
+    expect(result).toEqual({
+      sender: 'Alice',
+      body: 'Hello there',
+      bundleId: 'com.tinyspeck.slackmacgap',
+    });
+  });
+
+  it('extracts the first non-Notification string when body is an array', () => {
+    const result = extractMacNotification({
+      app: 'com.example.app',
+      req: {
+        titl: 'Bob',
+        body: ['SomethingNotificationInternal', 'Actual message', 'Ignored'],
+      },
+    });
+    expect(result?.body).toBe('Actual message');
+    expect(result?.sender).toBe('Bob');
+  });
+
+  it('derives sender from bundleId when titl is missing', () => {
+    const result = extractMacNotification({
+      app: 'com.apple.MobileSMS',
+      req: { body: 'New message' },
+    });
+    expect(result?.sender).toBe('MobileSMS');
+    expect(result?.body).toBe('New message');
+    expect(result?.bundleId).toBe('com.apple.MobileSMS');
+  });
+
+  it('falls back to "Unknown" when no sender can be derived', () => {
+    const result = extractMacNotification({
+      req: { body: 'Anonymous body' },
+    });
+    expect(result?.sender).toBe('Unknown');
+    expect(result?.bundleId).toBe('');
+  });
+
+  it('ignores non-string app field', () => {
+    const result = extractMacNotification({
+      app: 42,
+      req: { titl: 'T', body: 'B' },
+    });
+    expect(result?.bundleId).toBe('');
+  });
+});

--- a/src/main/monitors/mac.ts
+++ b/src/main/monitors/mac.ts
@@ -7,6 +7,7 @@ import {
   formatNotificationTimestamp,
   type LatestNotificationRecord,
 } from './base';
+import { extractMacNotification } from './macParser';
 
 // eslint-disable-next-line no-eval
 const nativeRequire = eval('require') as NodeRequire;
@@ -168,36 +169,7 @@ export class MacNotificationMonitor extends BaseNotificationMonitor {
     try {
       const parsed = bplist.parseBuffer(data);
       if (!parsed?.[0]) return null;
-
-      const root = parsed[0] as Record<string, unknown>;
-      const req = root.req as Record<string, unknown> | undefined;
-      if (!req) return null;
-
-      let body = '';
-      let sender = '';
-      const bundleId = typeof root.app === 'string' ? (root.app as string) : '';
-
-      if (typeof req.body === 'string') {
-        body = req.body;
-      } else if (Array.isArray(req.body)) {
-        const strings = (req.body as unknown[]).filter(
-          (item): item is string => typeof item === 'string' && !item.includes('Notification'),
-        );
-        body = strings[0] || String(req.body);
-      }
-
-      if (typeof req.titl === 'string') {
-        sender = req.titl;
-      }
-
-      if (!sender && bundleId) {
-        const parts = bundleId.split('.');
-        sender = parts[parts.length - 1];
-      }
-
-      if (!body) return null;
-
-      return { sender: sender || 'Unknown', body, bundleId };
+      return extractMacNotification(parsed[0] as Record<string, unknown>);
     } catch (err) {
       console.error('Failed to parse notification data:', err);
       return null;

--- a/src/main/monitors/macParser.ts
+++ b/src/main/monitors/macParser.ts
@@ -1,0 +1,49 @@
+/**
+ * Pure functions for extracting notification fields from a decoded bplist object.
+ * Kept free of native module imports (better-sqlite3 / bplist-parser) so it can be unit-tested.
+ */
+
+export interface ParsedMacNotification {
+  sender: string;
+  body: string;
+  bundleId: string;
+}
+
+/**
+ * Extract sender / body / bundleId from an already-decoded bplist root object.
+ * Returns null when the required `body` field cannot be found.
+ */
+export function extractMacNotification(
+  root: Record<string, unknown> | null | undefined,
+): ParsedMacNotification | null {
+  if (!root) return null;
+
+  const req = root.req as Record<string, unknown> | undefined;
+  if (!req) return null;
+
+  const bundleId = typeof root.app === 'string' ? (root.app as string) : '';
+
+  let body = '';
+  if (typeof req.body === 'string') {
+    body = req.body;
+  } else if (Array.isArray(req.body)) {
+    const strings = (req.body as unknown[]).filter(
+      (item): item is string => typeof item === 'string' && !item.includes('Notification'),
+    );
+    body = strings[0] || String(req.body);
+  }
+
+  let sender = '';
+  if (typeof req.titl === 'string') {
+    sender = req.titl;
+  }
+
+  if (!sender && bundleId) {
+    const parts = bundleId.split('.');
+    sender = parts[parts.length - 1];
+  }
+
+  if (!body) return null;
+
+  return { sender: sender || 'Unknown', body, bundleId };
+}

--- a/src/main/monitors/windows.test.ts
+++ b/src/main/monitors/windows.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+import {
+  FILETIME_TICKS_PER_SECOND,
+  FILETIME_UNIX_EPOCH_OFFSET,
+  fileTimeToUnixMs,
+  parseWindowsPayload,
+  unixSecondsToFileTime,
+} from './windowsParser';
+
+describe('FILETIME conversion', () => {
+  it('fileTimeToUnixMs returns 0 at the Unix epoch', () => {
+    const filetimeAtEpoch = FILETIME_UNIX_EPOCH_OFFSET * FILETIME_TICKS_PER_SECOND;
+    expect(fileTimeToUnixMs(filetimeAtEpoch)).toBe(0);
+  });
+
+  it('unixSecondsToFileTime and fileTimeToUnixMs round-trip', () => {
+    const unixSec = 1_700_000_000; // 2023-11-14T22:13:20Z
+    const ft = unixSecondsToFileTime(unixSec);
+    expect(fileTimeToUnixMs(ft)).toBe(unixSec * 1000);
+  });
+
+  it('unixSecondsToFileTime applies the 1601 epoch offset', () => {
+    // At Unix epoch, FILETIME should be exactly the offset in ticks.
+    expect(unixSecondsToFileTime(0)).toBe(FILETIME_UNIX_EPOCH_OFFSET * FILETIME_TICKS_PER_SECOND);
+  });
+});
+
+describe('parseWindowsPayload', () => {
+  it('returns null when payload has no text elements', () => {
+    expect(parseWindowsPayload('<toast><visual/></toast>', null)).toBeNull();
+    expect(parseWindowsPayload('', null)).toBeNull();
+  });
+
+  it('extracts a single <text> as body and derives sender from appId', () => {
+    const payload = '<toast><visual><binding><text>Hello</text></binding></visual></toast>';
+    const result = parseWindowsPayload(payload, 'com.microsoft.Teams2_8wekyb3d8bbwe');
+    expect(result?.body).toBe('Hello');
+    expect(result?.sender).toBe('Teams2');
+    expect(result?.appId).toBe('com.microsoft.Teams2_8wekyb3d8bbwe');
+  });
+
+  it('uses first <text> as sender and second as body when both are present', () => {
+    const payload =
+      '<toast><visual><binding><text>Alice</text><text>Hello there</text></binding></visual></toast>';
+    const result = parseWindowsPayload(payload, 'any.app.id');
+    expect(result?.sender).toBe('Alice');
+    expect(result?.body).toBe('Hello there');
+  });
+
+  it('handles <text> elements with attributes', () => {
+    const payload = '<toast><text id="1">Alice</text><text id="2">Hello</text></toast>';
+    const result = parseWindowsPayload(payload, null);
+    expect(result?.sender).toBe('Alice');
+    expect(result?.body).toBe('Hello');
+  });
+
+  it('trims whitespace inside <text> tags', () => {
+    const payload = '<toast><text>  spaced body  </text></toast>';
+    const result = parseWindowsPayload(payload, 'foo');
+    expect(result?.body).toBe('spaced body');
+  });
+
+  it('falls back to "Unknown" sender when only one text exists and appId is empty', () => {
+    const result = parseWindowsPayload('<toast><text>only</text></toast>', null);
+    expect(result?.sender).toBe('Unknown');
+    expect(result?.body).toBe('only');
+    expect(result?.appId).toBe('');
+  });
+
+  it('is case-insensitive for <text> tag', () => {
+    const payload = '<toast><Text>hey</Text></toast>';
+    const result = parseWindowsPayload(payload, 'app');
+    expect(result?.body).toBe('hey');
+  });
+
+  it('handles multiline text content', () => {
+    const payload = '<toast><text>line one\nline two</text></toast>';
+    const result = parseWindowsPayload(payload, 'app');
+    expect(result?.body).toBe('line one\nline two');
+  });
+});

--- a/src/main/monitors/windows.ts
+++ b/src/main/monitors/windows.ts
@@ -6,6 +6,7 @@ import {
   formatNotificationTimestamp,
   type LatestNotificationRecord,
 } from './base';
+import { fileTimeToUnixMs, parseWindowsPayload, unixSecondsToFileTime } from './windowsParser';
 
 // eslint-disable-next-line no-eval
 const nativeRequire = eval('require') as NodeRequire;
@@ -21,16 +22,11 @@ const Database = nativeRequire('better-sqlite3') as typeof import('better-sqlite
  * in the WAL file are visible immediately.
  */
 export class WindowsNotificationMonitor extends BaseNotificationMonitor {
-  private static readonly FILETIME_UNIX_EPOCH_OFFSET = 11644473600;
-  private static readonly FILETIME_TICKS_PER_SECOND = 10_000_000;
-
   private lastArrivalTime = 0;
   private dbPath = '';
 
   protected onStart(): void {
-    this.lastArrivalTime =
-      (Math.floor(Date.now() / 1000) + WindowsNotificationMonitor.FILETIME_UNIX_EPOCH_OFFSET) *
-      WindowsNotificationMonitor.FILETIME_TICKS_PER_SECOND;
+    this.lastArrivalTime = unixSecondsToFileTime(Math.floor(Date.now() / 1000));
     this.dbPath = path.join(
       os.homedir(),
       'AppData',
@@ -83,7 +79,7 @@ export class WindowsNotificationMonitor extends BaseNotificationMonitor {
           const payload = Buffer.isBuffer(row.Payload)
             ? row.Payload.toString('utf-8')
             : String(row.Payload);
-          return this.parsePayload(payload, row.PrimaryId);
+          return parseWindowsPayload(payload, row.PrimaryId);
         })
         .filter((p): p is NonNullable<typeof p> => p !== null);
 
@@ -152,15 +148,12 @@ export class WindowsNotificationMonitor extends BaseNotificationMonitor {
 
     return await Promise.all(
       rows.map(async (row) => {
-        const unixSeconds =
-          row.ArrivalTime / WindowsNotificationMonitor.FILETIME_TICKS_PER_SECOND -
-          WindowsNotificationMonitor.FILETIME_UNIX_EPOCH_OFFSET;
-        const timestamp = formatNotificationTimestamp(unixSeconds * 1000);
+        const timestamp = formatNotificationTimestamp(fileTimeToUnixMs(row.ArrivalTime));
 
         const payload = Buffer.isBuffer(row.Payload)
           ? row.Payload.toString('utf-8')
           : String(row.Payload);
-        const p = this.parsePayload(payload, row.PrimaryId);
+        const p = parseWindowsPayload(payload, row.PrimaryId);
         if (p !== null) {
           const appName = await resolveAppName(p.appId);
           return { id: row.Id, timestamp, sender: p.sender, body: p.body, appName, rawId: p.appId };
@@ -177,27 +170,5 @@ export class WindowsNotificationMonitor extends BaseNotificationMonitor {
         };
       }),
     );
-  }
-
-  private parsePayload(
-    payload: string,
-    appId: string | null,
-  ): { sender: string; body: string; appId: string } | null {
-    try {
-      const texts = [...payload.matchAll(/<text[^>]*>([\s\S]*?)<\/text>/gi)].map((m) =>
-        m[1].trim(),
-      );
-      if (texts.length === 0) return null;
-
-      const body = texts.length >= 2 ? texts[1] : texts[0];
-      const sender =
-        texts.length >= 2 ? texts[0] : (appId?.split('.').pop()?.replace(/_.*$/, '') ?? '');
-
-      if (!body) return null;
-      return { sender: sender || 'Unknown', body, appId: appId ?? '' };
-    } catch (err) {
-      console.error('Failed to parse notification payload:', err);
-      return null;
-    }
   }
 }

--- a/src/main/monitors/windowsParser.ts
+++ b/src/main/monitors/windowsParser.ts
@@ -45,18 +45,13 @@ export function parseWindowsPayload(
   payload: string,
   appId: string | null,
 ): ParsedWindowsNotification | null {
-  try {
-    const texts = [...payload.matchAll(/<text[^>]*>([\s\S]*?)<\/text>/gi)].map((m) => m[1].trim());
-    if (texts.length === 0) return null;
+  const texts = [...payload.matchAll(/<text[^>]*>([\s\S]*?)<\/text>/gi)].map((m) => m[1].trim());
+  if (texts.length === 0) return null;
 
-    const body = texts.length >= 2 ? texts[1] : texts[0];
-    const sender =
-      texts.length >= 2 ? texts[0] : (appId?.split('.').pop()?.replace(/_.*$/, '') ?? '');
+  const body = texts.length >= 2 ? texts[1] : texts[0];
+  const sender =
+    texts.length >= 2 ? texts[0] : (appId?.split('.').pop()?.replace(/_.*$/, '') ?? '');
 
-    if (!body) return null;
-    return { sender: sender || 'Unknown', body, appId: appId ?? '' };
-  } catch (err) {
-    console.error('Failed to parse notification payload:', err);
-    return null;
-  }
+  if (!body) return null;
+  return { sender: sender || 'Unknown', body, appId: appId ?? '' };
 }

--- a/src/main/monitors/windowsParser.ts
+++ b/src/main/monitors/windowsParser.ts
@@ -1,0 +1,62 @@
+/**
+ * Pure helpers for the Windows notification monitor.
+ * Kept free of native module imports (better-sqlite3) so it can be unit-tested.
+ *
+ * NOTE on precision: current FILETIME values (~1.3e17 ticks as of 2026) exceed
+ * Number.MAX_SAFE_INTEGER (~9e15), so raw ticks cannot be represented exactly as
+ * JS numbers. `fileTimeToUnixMs` is safe because `/ TICKS_PER_SECOND` scales the
+ * value back into the safe range before returning ms. `unixSecondsToFileTime`
+ * returns an approximate tick count (low bits may be rounded to the nearest
+ * ~100ns); this is acceptable for `onStart()` where the value is only used as a
+ * ">= lastArrival" cursor and sub-microsecond accuracy is irrelevant. If BigInt
+ * support is added to the poll query in the future, migrate both helpers.
+ */
+
+export const FILETIME_UNIX_EPOCH_OFFSET = 11644473600;
+export const FILETIME_TICKS_PER_SECOND = 10_000_000;
+
+export interface ParsedWindowsNotification {
+  sender: string;
+  body: string;
+  appId: string;
+}
+
+/**
+ * Convert a Windows FILETIME tick count (100-ns since 1601-01-01) to
+ * Unix epoch milliseconds.
+ */
+export function fileTimeToUnixMs(filetime: number): number {
+  const unixSeconds = filetime / FILETIME_TICKS_PER_SECOND - FILETIME_UNIX_EPOCH_OFFSET;
+  return unixSeconds * 1000;
+}
+
+/**
+ * Convert Unix epoch seconds to a Windows FILETIME tick count.
+ */
+export function unixSecondsToFileTime(unixSeconds: number): number {
+  return (unixSeconds + FILETIME_UNIX_EPOCH_OFFSET) * FILETIME_TICKS_PER_SECOND;
+}
+
+/**
+ * Extract sender / body / appId from a WNS toast XML payload string.
+ * Returns null when no <text> elements can be found.
+ */
+export function parseWindowsPayload(
+  payload: string,
+  appId: string | null,
+): ParsedWindowsNotification | null {
+  try {
+    const texts = [...payload.matchAll(/<text[^>]*>([\s\S]*?)<\/text>/gi)].map((m) => m[1].trim());
+    if (texts.length === 0) return null;
+
+    const body = texts.length >= 2 ? texts[1] : texts[0];
+    const sender =
+      texts.length >= 2 ? texts[0] : (appId?.split('.').pop()?.replace(/_.*$/, '') ?? '');
+
+    if (!body) return null;
+    return { sender: sender || 'Unknown', body, appId: appId ?? '' };
+  } catch (err) {
+    console.error('Failed to parse notification payload:', err);
+    return null;
+  }
+}

--- a/src/main/settings.test.ts
+++ b/src/main/settings.test.ts
@@ -1,0 +1,81 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: vi.fn(() => '/tmp/mascot-notifier-test'),
+  },
+}));
+
+const readFileSyncMock = vi.fn();
+const writeFileSyncMock = vi.fn();
+
+vi.mock('node:fs', () => ({
+  default: {
+    readFileSync: (...args: unknown[]) => readFileSyncMock(...args),
+    writeFileSync: (...args: unknown[]) => writeFileSyncMock(...args),
+  },
+}));
+
+// Import after mocks are set up.
+import { loadSettings, saveSettings } from './settings';
+
+describe('loadSettings', () => {
+  beforeEach(() => {
+    readFileSyncMock.mockReset();
+    writeFileSyncMock.mockReset();
+  });
+
+  it('returns defaults when the file does not exist', () => {
+    readFileSyncMock.mockImplementation(() => {
+      const err = new Error('ENOENT');
+      (err as NodeJS.ErrnoException).code = 'ENOENT';
+      throw err;
+    });
+    expect(loadSettings()).toEqual({
+      characterFile: 'dance.json',
+      displayDuration: 5000,
+    });
+  });
+
+  it('returns defaults when the file contains invalid JSON', () => {
+    readFileSyncMock.mockReturnValue('not-json');
+    expect(loadSettings()).toEqual({
+      characterFile: 'dance.json',
+      displayDuration: 5000,
+    });
+  });
+
+  it('merges defaults with the stored values', () => {
+    readFileSyncMock.mockReturnValue(JSON.stringify({ displayDuration: 8000 }));
+    expect(loadSettings()).toEqual({
+      characterFile: 'dance.json',
+      displayDuration: 8000,
+    });
+  });
+
+  it('lets stored values override defaults entirely when all fields are set', () => {
+    readFileSyncMock.mockReturnValue(
+      JSON.stringify({ characterFile: 'crab.json', displayDuration: 3000 }),
+    );
+    expect(loadSettings()).toEqual({
+      characterFile: 'crab.json',
+      displayDuration: 3000,
+    });
+  });
+});
+
+describe('saveSettings', () => {
+  beforeEach(() => {
+    writeFileSyncMock.mockReset();
+  });
+
+  it('writes JSON to the settings path', () => {
+    saveSettings({ characterFile: 'dance.json', displayDuration: 5000 });
+    expect(writeFileSyncMock).toHaveBeenCalledOnce();
+    const [, payload] = writeFileSyncMock.mock.calls[0];
+    expect(JSON.parse(payload as string)).toEqual({
+      characterFile: 'dance.json',
+      displayDuration: 5000,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- OS非公開DB依存のパース/変換ロジック (bplist, WNS XML, Core Data/FILETIME タイムスタンプ) の回帰検出を目的に、Vitestによる単体テスト基盤を導入
- 純粋関数を別モジュール (`macParser.ts` / `windowsParser.ts`) に切り出してテスト容易化、既存クラスからは委譲
- 5ファイル / 46テストケースで壊れやすい箇所をカバー。Electron API結合部やReact UIはスコープ外

## 変更ファイル

### 新規

- `src/main/monitors/macParser.ts` — `extractMacNotification` (bplistデコード後のroot → sender/body/bundleId)
- `src/main/monitors/windowsParser.ts` — FILETIME変換 + `parseWindowsPayload` (WNS XML)
- `src/main/monitors/base.test.ts` — `formatNotificationTimestamp`, `BaseNotificationMonitor.trimSeenCache` (LRU縮退動作)
- `src/main/monitors/mac.test.ts` — `extractMacNotification` 7ケース
- `src/main/monitors/windows.test.ts` — FILETIME変換 + `parseWindowsPayload` 10ケース
- `src/main/appNameResolver.test.ts` — `BoundedCache` (LRU), `resolveAppNameWin`, `fallbackName`, `normalizeWinId`
- `src/main/settings.test.ts` — `loadSettings` のデフォルトマージとフォールバック (electron/fsモック)

### 修正

- `src/main/monitors/mac.ts` — `parseNotificationData` 本体を `extractMacNotification` に委譲
- `src/main/monitors/windows.ts` — FILETIME定数/変換と `parsePayload` を `windowsParser` に委譲、class内から削除
- `src/main/appNameResolver.ts` — `BoundedCache` / `resolveAppNameWin` / `fallbackName` / `normalizeWinId` を `export` 化
- `package.json` — `vitest` を devDependency に追加、`test` / `test:watch` スクリプト追加

## スコープ外 (意図的)

- `src/main/index.ts` のElectron API結合部 (BrowserWindow/Tray/ipcMain)
- `MacNotificationMonitor.poll` / `fetchLatest` のSQLite I/O部分
- `resolveAppNameMac` (`mdfind`/`mdls`実行依存)
- React コンポーネント (`CharacterOverlay.tsx`, `SettingsApp.tsx`)
- E2E / Playwright

理由: モックコスト > リターン。手動確認の方が速い領域。

## Test plan

- [x] `npm test` が全46ケース pass
- [x] `npm run lint` (biome) クリーン
- [x] `npm run build` 成功 (既存のeval警告のみ)
- [ ] `npm run dev` でリファクタ後も通知を従来通り拾えること (手動確認)

🤖 Generated with [Claude Code](https://claude.com/claude-code)