### PR TITLE
feat: Windowsクロスビルドでx64/arm64をWIN_ARCH環境変数で切り替え可能にする

### DIFF
--- a/.claude/skills/dist-win/SKILL.md
+++ b/.claude/skills/dist-win/SKILL.md
@@ -7,7 +7,13 @@ description: Windows用ディストリビューションをビルドする
 
 Windows用のディストリビューションをビルドする。
 
+## アーキテクチャの指定
+
+- デフォルトは `arm64`
+- x64 向けにビルドする場合は `npm run dist:win:x64`（または `WIN_ARCH=x64 npm run dist:win`）を使用する
+
 ## Steps
 
-1. `npm run dist:win` を実行する
-2. ビルド結果の `dist/` ディレクトリから生成された `.exe` ファイルのパスとサイズを表示する
+1. ユーザーがアーキテクチャを指定している場合は対応するコマンドを選択する（指定なし → `npm run dist:win`、x64 → `npm run dist:win:x64`、arm64 → `npm run dist:win:arm64`）
+2. 選択したコマンドを実行する
+3. ビルド結果の `dist/` ディレクトリから生成された `.exe` ファイルのパスとサイズを表示する

--- a/README.md
+++ b/README.md
@@ -81,9 +81,19 @@ npm run format     # フォーマットのみ自動修正
 
 ## 配布用ビルド
 
+> **注意**: 配布用ビルドは **macOS 上でのみ実行可能**です。ビルドスクリプトは POSIX シェル構文（`${VAR:-default}`、`VAR=value npm run ...`）を使用しており、Windows の cmd / PowerShell では動作しません。
+
 ```bash
-npm run dist:mac   # macOS 配布用 (.dmg)
-npm run dist:win   # Windows 配布用 (.exe, NSIS インストーラー)
+npm run dist:mac        # macOS 配布用 (.dmg)
+npm run dist:win        # Windows 配布用 arm64 (.exe, NSIS インストーラー)
+npm run dist:win:x64    # Windows 配布用 x64
+npm run dist:win:arm64  # Windows 配布用 arm64（dist:win と同じ）
+```
+
+アーキテクチャは `WIN_ARCH` 環境変数でも指定できます：
+
+```bash
+WIN_ARCH=x64 npm run dist:win
 ```
 
 ### macOS からの Windows クロスビルド
@@ -95,9 +105,7 @@ npm run dist:win   # Windows 配布用 (.exe, NSIS インストーラー)
 3. `electron-builder --win` でパッケージング
 4. ビルド後、macOS 用の `better-sqlite3` バイナリを復元
 
-出力先: `dist/Mascot Notifier Setup x.x.x.exe`
-
-> 現在のスクリプトは arm64 をターゲットにしています。x64 向けにビルドする場合はスクリプト内の `--arch arm64` を `--arch x64` に変更してください。
+出力先: `dist/mascot-notifier-setup-x.x.x.exe`
 
 ## プロジェクト構成
 

--- a/doc/known-issues.md
+++ b/doc/known-issues.md
@@ -35,7 +35,9 @@
 
 - macOS から `npm run dist:win` でクロスビルド可能だが、`better-sqlite3` のネイティブバイナリは `prebuild-install` で事前ダウンロードが必要
 - electron-builder の `@electron/rebuild` はホストプラットフォーム向けにしかリビルドできないため、`-c.npmRebuild=false` で無効化している
-- ビルドスクリプト内の `--arch arm64` はハードコードされているため、x64 向けビルドには手動修正が必要
+- `WIN_ARCH` 環境変数でアーキテクチャを切り替え可能（デフォルト: `arm64`）
+  - x64 向け: `npm run dist:win:x64` または `WIN_ARCH=x64 npm run dist:win`
+  - arm64 向け: `npm run dist:win:arm64` または `npm run dist:win`
 
 ## OS 通知との共存（二重表示）
 

--- a/doc/setup.md
+++ b/doc/setup.md
@@ -24,21 +24,34 @@ npm run dev
 ```bash
 npm run build        # Vite ビルドのみ
 npm run dist:mac     # macOS 配布用 (.dmg)
-npm run dist:win     # Windows 配布用 (.exe, NSIS インストーラー)
+npm run dist:win     # Windows 配布用 arm64 (.exe, NSIS インストーラー)
+npm run dist:win:x64 # Windows 配布用 x64
 ```
 
 ### Windows 向けクロスビルド（macOS から）
 
+> **注意**: これらのスクリプトは macOS 上でのみ実行可能（POSIX シェル構文を使用）。
+
+```bash
+npm run dist:win        # arm64（デフォルト）
+npm run dist:win:x64    # x64
+npm run dist:win:arm64  # arm64（明示指定）
+```
+
+アーキテクチャは `WIN_ARCH` 環境変数でも切り替え可能：
+
+```bash
+WIN_ARCH=x64 npm run dist:win
+```
+
 `npm run dist:win` は以下を自動的に行う：
 
 1. `electron-vite build` でアプリをビルド
-2. `prebuild-install` で Windows arm64 用の `better-sqlite3` プリビルドバイナリをダウンロード
+2. `prebuild-install` で Windows 向けの `better-sqlite3` プリビルドバイナリをダウンロード
 3. `electron-builder --win` でパッケージング（ネイティブモジュールの自動リビルドはスキップ）
 4. ビルド後、macOS 用の `better-sqlite3` バイナリを復元
 
-出力先: `dist/Mascot Notifier Setup x.x.x.exe`
-
-> 現在のスクリプトは arm64 をターゲットにしている。x64 向けにビルドする場合はスクリプト内の `--arch arm64` を `--arch x64` に変更する。
+出力先: `dist/mascot-notifier-setup-x.x.x.exe`
 
 ## macOS フルディスクアクセスの設定
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,9 @@
     "lint:fix": "biome check --write src/",
     "format": "biome format --write src/",
     "dist:mac": "npm run build && electron-builder --mac",
-    "dist:win": "npm run build && cd node_modules/better-sqlite3 && npx prebuild-install --platform win32 --arch arm64 --runtime electron --target $(node -p \"require('../electron/package.json').version\") && cd ../.. && electron-builder --win -c.npmRebuild=false; cd node_modules/better-sqlite3 && npx prebuild-install --runtime electron --target $(node -p \"require('../electron/package.json').version\")"
+    "dist:win": "npm run build && cd node_modules/better-sqlite3 && npx prebuild-install --platform win32 --arch ${WIN_ARCH:-arm64} --runtime electron --target $(node -p \"require('../electron/package.json').version\") && cd ../.. && electron-builder --win --${WIN_ARCH:-arm64} -c.npmRebuild=false; RESULT=$?; cd node_modules/better-sqlite3 && npx prebuild-install --runtime electron --target $(node -p \"require('../electron/package.json').version\"); exit $RESULT",
+    "dist:win:x64": "WIN_ARCH=x64 npm run dist:win",
+    "dist:win:arm64": "WIN_ARCH=arm64 npm run dist:win"
   },
   "build": {
     "appId": "com.mascot-notifier.app",
@@ -42,7 +44,8 @@
     },
     "nsis": {
       "oneClick": true,
-      "perMachine": false
+      "perMachine": false,
+      "artifactName": "${name}-setup-${version}.exe"
     },
     "extraResources": [
       {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "lint:fix": "biome check --write src/",
     "format": "biome format --write src/",
     "dist:mac": "npm run build && electron-builder --mac",
-    "dist:win": "npm run build && cd node_modules/better-sqlite3 && npx prebuild-install --platform win32 --arch ${WIN_ARCH:-arm64} --runtime electron --target $(node -p \"require('../electron/package.json').version\") && cd ../.. && electron-builder --win --${WIN_ARCH:-arm64} -c.npmRebuild=false; RESULT=$?; cd node_modules/better-sqlite3 && npx prebuild-install --runtime electron --target $(node -p \"require('../electron/package.json').version\"); exit $RESULT",
+    "dist:win": "npm run build && ELECTRON_VER=$(node -p \"require('./node_modules/electron/package.json').version\") && cd node_modules/better-sqlite3 && npx prebuild-install --platform win32 --arch ${WIN_ARCH:-arm64} --runtime electron --target $ELECTRON_VER && cd ../.. && electron-builder --win --${WIN_ARCH:-arm64} -c.npmRebuild=false; RESULT=$?; (cd node_modules/better-sqlite3 && npx prebuild-install --runtime electron --target $ELECTRON_VER); RESTORE=$?; [ $RESULT -ne 0 ] && exit $RESULT; exit $RESTORE",
     "dist:win:x64": "WIN_ARCH=x64 npm run dist:win",
     "dist:win:arm64": "WIN_ARCH=arm64 npm run dist:win"
   },


### PR DESCRIPTION
## Summary

- `dist:win` スクリプトの `--arch arm64` を `${WIN_ARCH:-arm64}` に変更し、環境変数でアーキテクチャを切り替え可能にした
- `dist:win:x64` / `dist:win:arm64` の利便性スクリプトを追加
- `electron-builder` にもアーキテクチャフラグ（`--x64` / `--arm64`）を渡すよう修正
- エラーハンドリング改善: `RESULT=$?` パターンで electron-builder の終了コードを復元処理後も正しく伝播
- `nsis.artifactName` を `mascot-notifier-setup-${version}.exe` に設定（ファイル名のスペースを排除）
- README・known-issues・dist-win スキルに macOS 限定制約と新コマンドを記載

## Test plan

- [x] `npm run dist:win:x64` で Windows x64 向けインストーラーが `dist/mascot-notifier-setup-0.1.0.exe` に生成されることを確認
- [x] `npm run dist:mac` で macOS 向け `.dmg` が正常に生成されることを確認
- [x] ビルド後に macOS 用 `better-sqlite3` バイナリが復元されていることを確認

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)