### PR TITLE
docs: ドキュメントと実装の不一致を修正（issue #3）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,16 +9,16 @@ macOSの通知センターを監視し、透明なオーバーレイウィンド
 ## コマンド
 
 ```bash
-npm run dev       # ホットリロード付き開発サーバー
-npm run build     # プロダクションビルド（./out/ に出力）
-npm run preview   # ビルド済みアプリのプレビュー
-npm run lint      # Biomeによるlint + formatチェック
-npm run lint:fix  # lint + format自動修正
-npm run format    # フォーマットのみ自動修正
-npm install       # 依存関係インストール + ネイティブモジュール再ビルド（better-sqlite3）
+npm run dev           # ホットリロード付き開発サーバー
+npm run build         # プロダクションビルド（./out/ に出力）
+npm run preview       # ビルド済みアプリのプレビュー
+npm test              # vitest（1回実行）
+npm run test:watch    # vitest（ウォッチモード）
+npm run lint          # Biomeによるlint + formatチェック
+npm run lint:fix      # lint + format自動修正
+npm run format        # フォーマットのみ自動修正
+npm install           # 依存関係インストール + ネイティブモジュール再ビルド（better-sqlite3）
 ```
-
-テストコマンドは未設定。
 
 ### ディストリビューション
 
@@ -35,7 +35,7 @@ Electronの3プロセス構成：
 
 ### 通知パイプライン
 
-`NotificationMonitor` (`src/main/notificationMonitor.ts`) がmacOS通知センターのSQLiteデータベースを3秒ごとにポーリングし、`bplist-parser` でバイナリplistデータをデコード、`rec_id` で重複排除してIPCでRendererに送信する。オーバーレイウィンドウはフレームなし・透明・最前面・クリックスルー。
+`createNotificationMonitor()` (`src/main/notificationMonitor.ts`) が `process.platform` に応じて `MacNotificationMonitor` または `WindowsNotificationMonitor` のインスタンスを返すファクトリ。各モニターは3秒ごとにSQLite DBをポーリングし、`rec_id` / `Id` で重複排除してIPCでRendererに送信する。オーバーレイウィンドウはフレームなし・透明・最前面・クリックスルー。
 
 ### 実装上の重要ポイント
 

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -6,12 +6,15 @@
 Electron App
 ├── Main Process (src/main/)
 │   ├── index.ts                  # アプリ起動・ウィンドウ管理・Tray制御・ファイルログ
-│   ├── notificationMonitor.ts    # プラットフォーム別モニターのファクトリ（遅延読み込み）
+│   ├── notificationMonitor.ts    # プラットフォーム別モニターのファクトリ（実行時プラットフォーム選択）
+│   ├── appNameResolver.ts        # バンドルID / PrimaryId → 表示名変換（LRUキャッシュ付き）
 │   ├── settings.ts               # 設定の永続化
 │   └── monitors/
 │       ├── base.ts               # BaseNotificationMonitor（共通ロジック）
 │       ├── mac.ts                # macOS通知監視
-│       └── windows.ts            # Windows通知監視
+│       ├── macParser.ts          # bplistデコード済みオブジェクトのパース（純粋関数）
+│       ├── windows.ts            # Windows通知監視
+│       └── windowsParser.ts     # WNS XML ペイロードのパース（純粋関数）
 ├── Preload (src/preload/)
 │   └── index.ts                  # IPC ブリッジ (contextBridge)
 └── Renderer Process (src/renderer/)
@@ -31,7 +34,37 @@ Electron App
 - `emitPermissionErrorOnce()` — 権限エラー時に `'permission-error'` を1回だけ発火
 - `trimSeenCache()` — `seenIds` が500件を超えたら古いエントリを削除（ゼロアロケーション）
 
-`notificationMonitor.ts` は `process.platform` に応じてモジュールを **遅延読み込み** する。これにより、macOS上でWindows用のネイティブモジュールをロードする問題を回避。
+`notificationMonitor.ts` は `MacNotificationMonitor` と `WindowsNotificationMonitor` を静的 import し、`createNotificationMonitor()` が `process.platform` を見て適切なインスタンスを返すファクトリパターン。両クラスのモジュール自体は常にロードされる。
+
+## アプリ名解決（`appNameResolver.ts`）
+
+通知の `bundleId` / `PrimaryId` を人間が読めるアプリ名に変換する。
+
+| 優先順位 | macOS | Windows |
+|---|---|---|
+| 1 | `KNOWN_APPS` テーブル（ハードコード） | `KNOWN_APPS` テーブル（ハードコード） |
+| 2 | LRU キャッシュ（最大 256 件） | LRU キャッシュ（最大 256 件） |
+| 3 | `mdfind` + `mdls` でバンドル ID → 表示名を解決 | `PrimaryId` の `.`/`!` 区切りパース |
+| 4 | バンドル ID の末尾セグメント（フォールバック） | PWA ホスト名（`KNOWN_PWA_HOSTS`）または hostname の逆順セグメント |
+
+- 同一 ID への並行リクエストは `inflight` Map で重複解決を防止
+- `normalizeWinId()` — `AppId!SomeApp` 形式から `!` 以降と `_version` サフィックスを除去してキャッシュキーを正規化
+
+## 通知パースモジュール（`macParser.ts` / `windowsParser.ts`）
+
+native モジュール（`better-sqlite3` / `bplist-parser`）への依存を持たない純粋関数として切り出されており、ユニットテスト可能。
+
+- `extractMacNotification(root)` — デコード済み bplist オブジェクトから `{ sender, body, bundleId }` を抽出
+- `parseWindowsPayload(payload, appId)` — XML 文字列から `{ sender, body, appId }` を抽出（`<text>` 要素を正規表現でパース、`<text>` が1つの場合は `appId` から送信者名を推定）
+
+## 設定永続化（`settings.ts`）
+
+| 項目 | 内容 |
+|---|---|
+| 保存先 | `app.getPath('userData')/settings.json` |
+| 保存項目 | `characterFile`（Lottie JSON ファイル名）、`displayDuration`（表示ミリ秒、デフォルト 5000） |
+| 読み込み | `loadSettings()` — ファイルが存在しない場合はデフォルト値を返す |
+| 保存 | `saveSettings(settings)` — JSON ファイルに同期書き込み |
 
 ## 通知取得の仕組み（macOS）
 
@@ -142,6 +175,15 @@ Main Process --[notification]--> Preload --[electronAPI.onNotification]--> Rende
 Main Process --[settings-changed]--> Preload --[electronAPI.onSettingsChanged]--> Renderer
 Renderer --[get-settings / save-settings]--> Preload --[ipcMain.handle]--> Main Process
 ```
+
+### Preload API サーフェス（`window.electronAPI`）
+
+| メソッド | 引数 | 戻り値 | 説明 |
+|---|---|---|---|
+| `onNotification(cb)` | `(data: { sender, body, appName? }) => void` | `() => void`（解除関数） | 通知受信リスナーを登録 |
+| `onSettingsChanged(cb)` | `(settings: { characterFile, displayDuration }) => void` | `() => void`（解除関数） | 設定変更リスナーを登録 |
+| `getSettings()` | — | `Promise<{ characterFile, displayDuration }>` | 現在の設定を取得 |
+| `saveSettings(settings)` | `{ characterFile, displayDuration }` | `Promise<void>` | 設定を保存 |
 
 ## ネイティブモジュールの取り扱い
 

--- a/doc/known-issues.md
+++ b/doc/known-issues.md
@@ -26,9 +26,8 @@
 
 ## eval('require') の使用
 
-- `better-sqlite3` と `bplist-parser` のロードに `eval('require')` を使用
+- `mac.ts` と `windows.ts` 内のネイティブモジュール（`better-sqlite3`、`bplist-parser`）のロードに `eval('require')` を使用
 - ビルド時に Vite から警告が出るが、electron-vite の `ssr.noExternal: true` 強制を回避するための意図的な使用
-- `notificationMonitor.ts` でもプラットフォーム別モジュールの遅延読み込みに使用
 - セキュリティ上のリスクは低い（ハードコードされたモジュール名のみ使用）
 
 ## Windows 向けクロスビルド

--- a/doc/known-issues.md
+++ b/doc/known-issues.md
@@ -26,7 +26,7 @@
 
 ## eval('require') の使用
 
-- `mac.ts` と `windows.ts` 内のネイティブモジュール（`better-sqlite3`、`bplist-parser`）のロードに `eval('require')` を使用
+- `mac.ts` では `better-sqlite3` と `bplist-parser`、`windows.ts` では `better-sqlite3` のロードに `eval('require')` を使用
 - ビルド時に Vite から警告が出るが、electron-vite の `ssr.noExternal: true` 強制を回避するための意図的な使用
 - セキュリティ上のリスクは低い（ハードコードされたモジュール名のみ使用）
 


### PR DESCRIPTION
## Summary

- `doc/architecture.md` / `doc/known-issues.md` / `CLAUDE.md` の「遅延読み込み」誤記を修正（issue #3）
  - `notificationMonitor.ts` は静的 import + ファクトリパターンであり、遅延読み込みは行っていない
  - `eval('require')` は `mac.ts` と `windows.ts` 内のネイティブモジュールのみが対象
- ドキュメント監査で発見した欠落セクションを `doc/architecture.md` に追加
  - `appNameResolver.ts`（バンドルID → 表示名変換のロジック・優先順位）
  - `macParser.ts` / `windowsParser.ts`（純粋関数パースモジュール・実際の関数名）
  - 設定永続化（保存先パス・保存項目）
  - Preload API サーフェス（`window.electronAPI` の全メソッド）
- `CLAUDE.md` のテストコマンド誤記を修正（`テストコマンドは未設定` → vitest コマンドを記載）

## Test plan

- [ ] `doc/architecture.md` の記述が `src/main/notificationMonitor.ts`（静的import）と一致していることを確認
- [ ] `doc/known-issues.md` の `eval('require')` 記述が `mac.ts` / `windows.ts` の実装と一致していることを確認
- [ ] `CLAUDE.md` のテストコマンドで `npm test` が正常に実行されることを確認

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)