### PR TITLE
feat: 通知履歴タブを設定ウィンドウに追加（issue #9）

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -60,6 +60,7 @@ if (app.isReady()) {
   app.whenReady().then(initFileLogging);
 }
 
+import { addDisplayedNotification, getHistoryData } from './notificationHistory';
 import { type BaseNotificationMonitor, createNotificationMonitor } from './notificationMonitor';
 import { type AppSettings, loadSettings, saveSettings } from './settings';
 
@@ -127,16 +128,21 @@ function createOverlayWindow(): BrowserWindow {
   return win;
 }
 
-function createSettingsWindow(): void {
+type SettingsTab = 'settings' | 'history';
+
+function createSettingsWindow(initialTab: SettingsTab = 'settings'): void {
   if (settingsWindow) {
+    settingsWindow.webContents.send('navigate-tab', initialTab);
     settingsWindow.focus();
     return;
   }
 
   settingsWindow = new BrowserWindow({
-    width: 400,
-    height: 430,
-    resizable: false,
+    width: 480,
+    height: 600,
+    minWidth: 400,
+    minHeight: 500,
+    resizable: true,
     webPreferences: {
       preload: preloadPath,
       contextIsolation: true,
@@ -144,71 +150,11 @@ function createSettingsWindow(): void {
     },
   });
 
-  loadRenderer(settingsWindow, 'settings');
+  loadRenderer(settingsWindow, initialTab);
 
   settingsWindow.on('closed', () => {
     settingsWindow = null;
   });
-}
-
-async function handleFetchLatest(): Promise<void> {
-  if (!monitor) {
-    await dialog.showMessageBox({
-      type: 'info',
-      title: '最新10件を確認',
-      message: 'モニターが初期化されていません。',
-      buttons: ['OK'],
-    });
-    return;
-  }
-
-  try {
-    const records = await monitor.fetchLatest(10);
-
-    if (records.length === 0) {
-      await dialog.showMessageBox({
-        type: 'info',
-        title: '最新10件を確認',
-        message: '通知が見つかりませんでした。',
-        detail: 'データベースに通知が存在しないか、まだ記録されていません。',
-        buttons: ['閉じる'],
-      });
-      return;
-    }
-
-    const lines = records.map((r, i) => {
-      const num = String(i + 1).padStart(2, ' ');
-      const senderPart = r.sender !== r.appName ? ` - ${r.sender}` : '';
-      return `${num}. [${r.timestamp}] ${r.appName}${senderPart}\n    ${r.body}\n    (ID: ${r.id}, ${r.rawId})`;
-    });
-
-    await dialog.showMessageBox({
-      type: 'info',
-      title: `最新${records.length}件の通知`,
-      message: `データベースから取得した最新${records.length}件（新しい順）`,
-      detail: lines.join('\n\n'),
-      buttons: ['閉じる'],
-    });
-  } catch (err) {
-    const code = (err as NodeJS.ErrnoException).code ?? '';
-    const message = (err as Error).message ?? '';
-    const isPermission =
-      code === 'ENOENT' ||
-      code === 'EACCES' ||
-      code === 'SQLITE_CANTOPEN' ||
-      message.includes('unable to open database') ||
-      message.includes('directory does not exist');
-
-    await dialog.showMessageBox({
-      type: 'warning',
-      title: '最新10件を確認 - エラー',
-      message: isPermission
-        ? 'データベースにアクセスできませんでした。'
-        : '通知の取得中にエラーが発生しました。',
-      detail: isPermission ? 'フルディスクアクセス権限が必要な場合があります。' : message,
-      buttons: ['OK'],
-    });
-  }
 }
 
 function createTray(): void {
@@ -232,9 +178,9 @@ function createTray(): void {
       },
     },
     {
-      label: '最新10件を確認',
+      label: '最新30件を確認',
       click: () => {
-        void handleFetchLatest();
+        createSettingsWindow('history');
       },
     },
     { type: 'separator' },
@@ -275,6 +221,32 @@ app.whenReady().then(() => {
     const { x, y } = getOverlayPosition(settings);
     overlayWindow?.setPosition(x, y);
   });
+  ipcMain.handle('get-notification-history', async () => {
+    const dbRecords = monitor ? await monitor.fetchLatest(40) : [];
+    const dbIdSet = new Set(dbRecords.map((r) => String(r.id)));
+
+    const { displayedIds, historyOnly } = getHistoryData(dbIdSet);
+
+    const markedDbRecords = dbRecords.map((r) => ({
+      ...r,
+      displayedByApp: displayedIds.has(String(r.id)),
+    }));
+
+    const historyOnlyRecords = historyOnly.map((e) => ({
+      id: Number(e.dbId),
+      timestamp: e.timestamp,
+      unixMs: e.unixMs,
+      sender: e.sender,
+      body: e.body,
+      appName: e.appName,
+      rawId: e.rawId,
+      displayedByApp: true as const,
+    }));
+
+    return [...markedDbRecords, ...historyOnlyRecords]
+      .sort((a, b) => b.unixMs - a.unixMs)
+      .slice(0, 30);
+  });
 
   monitor = createNotificationMonitor();
   monitor.on('started', () => {
@@ -286,6 +258,7 @@ app.whenReady().then(() => {
   });
   monitor.on('notification', (notification) => {
     overlayWindow?.webContents.send('notification', notification);
+    addDisplayedNotification(notification);
   });
   monitor.on('permission-error', async () => {
     if (process.platform === 'darwin') {

--- a/src/main/monitors/base.ts
+++ b/src/main/monitors/base.ts
@@ -4,15 +4,20 @@ export interface NotificationData {
   sender: string;
   body: string;
   appName?: string;
+  dbId?: string;
+  unixMs?: number;
+  rawId?: string;
 }
 
 export interface LatestNotificationRecord {
   id: number;
   timestamp: string;
+  unixMs: number;
   sender: string;
   body: string;
   appName: string;
   rawId: string;
+  displayedByApp: boolean;
 }
 
 export function formatNotificationTimestamp(unixMs: number): string {

--- a/src/main/monitors/mac.ts
+++ b/src/main/monitors/mac.ts
@@ -68,17 +68,26 @@ export class MacNotificationMonitor extends BaseNotificationMonitor {
         return true;
       });
 
-      const parsed = newRows
-        .map((row) => this.parseNotificationData(row.data))
-        .filter((p): p is NonNullable<typeof p> => p !== null);
+      const results = await Promise.all(
+        newRows.map(async (row) => {
+          const p = this.parseNotificationData(row.data);
+          if (p === null) return null;
+          const appName = await resolveAppName(p.bundleId);
+          return {
+            sender: p.sender,
+            body: p.body,
+            appName,
+            dbId: String(row.rec_id),
+            unixMs: (row.delivered_date + MacNotificationMonitor.CORE_DATA_EPOCH_OFFSET) * 1000,
+            rawId: p.bundleId,
+          };
+        }),
+      );
 
-      const appNames = await Promise.all(parsed.map((p) => resolveAppName(p.bundleId)));
-
-      for (let i = 0; i < parsed.length; i++) {
-        const { sender, body } = parsed[i];
-        const appName = appNames[i];
-        console.log('New notification:', appName, '-', sender, '-', body);
-        this.emit('notification', { sender, body, appName });
+      for (const n of results) {
+        if (n === null) continue;
+        console.log('New notification:', n.appName, '-', n.sender, '-', n.body);
+        this.emit('notification', n);
       }
 
       if (rows.length > 0) {
@@ -129,15 +138,18 @@ export class MacNotificationMonitor extends BaseNotificationMonitor {
         );
 
         const p = this.parseNotificationData(row.data);
+        const unixMs = (row.delivered_date + MacNotificationMonitor.CORE_DATA_EPOCH_OFFSET) * 1000;
         if (p !== null) {
           const appName = await resolveAppName(p.bundleId);
           return {
             id: row.rec_id,
             timestamp,
+            unixMs,
             sender: p.sender,
             body: p.body,
             appName,
             rawId: p.bundleId,
+            displayedByApp: false,
           };
         }
 
@@ -154,10 +166,12 @@ export class MacNotificationMonitor extends BaseNotificationMonitor {
         return {
           id: row.rec_id,
           timestamp,
+          unixMs,
           sender: '(不明)',
           body: '(パース失敗)',
           appName: bundleId || '(不明)',
           rawId: bundleId,
+          displayedByApp: false,
         };
       }),
     );

--- a/src/main/monitors/windows.ts
+++ b/src/main/monitors/windows.ts
@@ -74,22 +74,29 @@ export class WindowsNotificationMonitor extends BaseNotificationMonitor {
         return true;
       });
 
-      const parsed = newRows
-        .map((row) => {
+      const results = await Promise.all(
+        newRows.map(async (row) => {
           const payload = Buffer.isBuffer(row.Payload)
             ? row.Payload.toString('utf-8')
             : String(row.Payload);
-          return parseWindowsPayload(payload, row.PrimaryId);
-        })
-        .filter((p): p is NonNullable<typeof p> => p !== null);
+          const p = parseWindowsPayload(payload, row.PrimaryId);
+          if (p === null) return null;
+          const appName = await resolveAppName(p.appId);
+          return {
+            sender: p.sender,
+            body: p.body,
+            appName,
+            dbId: String(row.Id),
+            unixMs: fileTimeToUnixMs(row.ArrivalTime),
+            rawId: p.appId,
+          };
+        }),
+      );
 
-      const appNames = await Promise.all(parsed.map((p) => resolveAppName(p.appId)));
-
-      for (let i = 0; i < parsed.length; i++) {
-        const { sender, body, appId } = parsed[i];
-        const appName = appNames[i];
-        console.log('New notification:', appName, `(${appId})`, '-', sender, '-', body);
-        this.emit('notification', { sender, body, appName });
+      for (const n of results) {
+        if (n === null) continue;
+        console.log('New notification:', n.appName, `(${n.rawId})`, '-', n.sender, '-', n.body);
+        this.emit('notification', n);
       }
 
       if (rows.length > 0) {
@@ -154,19 +161,31 @@ export class WindowsNotificationMonitor extends BaseNotificationMonitor {
           ? row.Payload.toString('utf-8')
           : String(row.Payload);
         const p = parseWindowsPayload(payload, row.PrimaryId);
+        const unixMs = fileTimeToUnixMs(row.ArrivalTime);
         if (p !== null) {
           const appName = await resolveAppName(p.appId);
-          return { id: row.Id, timestamp, sender: p.sender, body: p.body, appName, rawId: p.appId };
+          return {
+            id: row.Id,
+            timestamp,
+            unixMs,
+            sender: p.sender,
+            body: p.body,
+            appName,
+            rawId: p.appId,
+            displayedByApp: false,
+          };
         }
 
         const appId = row.PrimaryId ?? '';
         return {
           id: row.Id,
           timestamp,
+          unixMs,
           sender: '(不明)',
           body: '(パース失敗)',
           appName: appId || '(不明)',
           rawId: appId,
+          displayedByApp: false,
         };
       }),
     );

--- a/src/main/notificationHistory.ts
+++ b/src/main/notificationHistory.ts
@@ -1,0 +1,82 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { app } from 'electron';
+import { formatNotificationTimestamp } from './monitors/base';
+
+interface DisplayedEntry {
+  dbId: string;
+  unixMs: number;
+  timestamp: string;
+  sender: string;
+  body: string;
+  appName: string;
+  rawId: string;
+}
+
+export interface HistoryData {
+  displayedIds: Set<string>;
+  historyOnly: DisplayedEntry[];
+}
+
+const MAX_ENTRIES = 200;
+let cache: DisplayedEntry[] | null = null;
+
+function getHistoryPath(): string {
+  return path.join(app.getPath('userData'), 'displayed-notifications.json');
+}
+
+function getEntries(): DisplayedEntry[] {
+  if (cache === null) {
+    try {
+      cache = JSON.parse(fs.readFileSync(getHistoryPath(), 'utf-8')) as DisplayedEntry[];
+    } catch {
+      cache = [];
+    }
+  }
+  return cache;
+}
+
+function flushAsync(): void {
+  fs.promises.writeFile(getHistoryPath(), JSON.stringify(cache ?? [])).catch((err) => {
+    console.error('Failed to save notification history:', err);
+  });
+}
+
+export function addDisplayedNotification(data: {
+  dbId?: string;
+  unixMs?: number;
+  sender: string;
+  body: string;
+  appName?: string;
+  rawId?: string;
+}): void {
+  if (!data.dbId) return;
+
+  const entries = getEntries();
+  if (entries.some((e) => e.dbId === data.dbId)) return;
+
+  const unixMs = data.unixMs ?? Date.now();
+  entries.unshift({
+    dbId: data.dbId,
+    unixMs,
+    timestamp: formatNotificationTimestamp(unixMs),
+    sender: data.sender,
+    body: data.body,
+    appName: data.appName ?? '',
+    rawId: data.rawId ?? '',
+  });
+
+  if (entries.length > MAX_ENTRIES) {
+    entries.splice(MAX_ENTRIES);
+  }
+
+  flushAsync();
+}
+
+export function getHistoryData(dbIdSet: Set<string>): HistoryData {
+  const entries = getEntries();
+  return {
+    displayedIds: new Set(entries.map((e) => e.dbId)),
+    historyOnly: entries.filter((e) => !dbIdSet.has(e.dbId)),
+  };
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -24,4 +24,6 @@ contextBridge.exposeInMainWorld('electronAPI', {
     displayDuration: number;
     displayPosition: 'top-right' | 'bottom-right';
   }) => ipcRenderer.invoke('save-settings', settings),
+  getNotificationHistory: () => ipcRenderer.invoke('get-notification-history'),
+  onNavigateTab: (callback: (tab: string) => void) => createListener('navigate-tab', callback),
 });

--- a/src/renderer/src/SettingsApp.tsx
+++ b/src/renderer/src/SettingsApp.tsx
@@ -14,11 +14,30 @@ const POSITION_OPTIONS: { label: string; value: 'top-right' | 'bottom-right' }[]
 const MIN_DURATION = 1;
 const MAX_DURATION = 10;
 
-export const SettingsApp: React.FC = () => {
+type Tab = 'settings' | 'history';
+
+type HistoryState =
+  | { status: 'idle' }
+  | { status: 'loading' }
+  | { status: 'success'; records: LatestNotificationRecord[] }
+  | { status: 'error'; message: string };
+
+interface SettingsAppProps {
+  initialTab?: Tab;
+}
+
+export const SettingsApp: React.FC<SettingsAppProps> = ({ initialTab = 'settings' }) => {
+  const [activeTab, setActiveTab] = useState<Tab>(initialTab);
+
+  // 設定タブ
   const [characterFile, setCharacterFile] = useState('dance.json');
   const [displayDuration, setDisplayDuration] = useState(5);
   const [displayPosition, setDisplayPosition] = useState<'top-right' | 'bottom-right'>('top-right');
   const [saved, setSaved] = useState(false);
+
+  // 通知履歴タブ
+  const [historyState, setHistoryState] = useState<HistoryState>({ status: 'idle' });
+  const [refreshKey, setRefreshKey] = useState(0);
 
   useEffect(() => {
     window.electronAPI.getSettings().then((settings) => {
@@ -27,6 +46,24 @@ export const SettingsApp: React.FC = () => {
       setDisplayPosition(settings.displayPosition ?? 'top-right');
     });
   }, []);
+
+  // メインプロセスからのタブ切り替えイベント
+  useEffect(() => {
+    return window.electronAPI.onNavigateTab((tab) => {
+      if (tab === 'settings' || tab === 'history') setActiveTab(tab as Tab);
+    });
+  }, []);
+
+  // 通知履歴の取得（refreshKey は更新ボタン押下時の再フェッチトリガー）
+  // biome-ignore lint/correctness/useExhaustiveDependencies: refreshKey intentionally triggers re-fetch
+  useEffect(() => {
+    if (activeTab !== 'history') return;
+    setHistoryState({ status: 'loading' });
+    window.electronAPI
+      .getNotificationHistory()
+      .then((records) => setHistoryState({ status: 'success', records }))
+      .catch((err) => setHistoryState({ status: 'error', message: String(err) }));
+  }, [activeTab, refreshKey]);
 
   const isInvalid = displayDuration < MIN_DURATION || displayDuration > MAX_DURATION;
 
@@ -43,118 +80,300 @@ export const SettingsApp: React.FC = () => {
   return (
     <div
       style={{
-        padding: '24px 24px 40px',
         fontFamily: '-apple-system, BlinkMacSystemFont, sans-serif',
+        height: '100vh',
+        display: 'flex',
+        flexDirection: 'column',
       }}
     >
-      <h2 style={{ margin: '0 0 24px', fontSize: 18 }}>設定</h2>
-
-      <div style={{ marginBottom: 20 }}>
-        <label
-          htmlFor="character-select"
-          style={{ display: 'block', marginBottom: 6, fontSize: 14, fontWeight: 600 }}
-        >
-          キャラクター
-        </label>
-        <select
-          id="character-select"
-          value={characterFile}
-          onChange={(e) => setCharacterFile(e.target.value)}
-          style={{
-            width: '100%',
-            padding: '8px 12px',
-            fontSize: 14,
-            borderRadius: 6,
-            border: '1px solid #ccc',
-          }}
-        >
-          {CHARACTER_OPTIONS.map((opt) => (
-            <option key={opt.value} value={opt.value}>
-              {opt.label}
-            </option>
-          ))}
-        </select>
+      {/* タブバー */}
+      <div
+        style={{
+          display: 'flex',
+          borderBottom: '2px solid #eee',
+          padding: '0 24px',
+          flexShrink: 0,
+        }}
+      >
+        {(['settings', 'history'] as Tab[]).map((tab) => (
+          <button
+            key={tab}
+            type="button"
+            onClick={() => setActiveTab(tab)}
+            style={{
+              padding: '14px 20px 12px',
+              fontSize: 14,
+              border: 'none',
+              background: 'none',
+              cursor: 'pointer',
+              borderBottom: activeTab === tab ? '2px solid #6B4EE6' : '2px solid transparent',
+              color: activeTab === tab ? '#6B4EE6' : '#666',
+              fontWeight: activeTab === tab ? 700 : 400,
+              marginBottom: -2,
+            }}
+          >
+            {tab === 'settings' ? '設定' : '通知履歴'}
+          </button>
+        ))}
       </div>
 
-      <fieldset style={{ border: 'none', padding: 0, margin: '0 0 20px' }}>
-        <legend style={{ marginBottom: 6, fontSize: 14, fontWeight: 600, padding: 0 }}>
-          表示位置
-        </legend>
-        <div style={{ display: 'flex', gap: 24 }}>
-          {POSITION_OPTIONS.map((opt) => (
+      {/* 設定タブ */}
+      {activeTab === 'settings' && (
+        <div style={{ padding: '24px 24px 40px', overflowY: 'auto' }}>
+          <div style={{ marginBottom: 20 }}>
             <label
-              key={opt.value}
+              htmlFor="character-select"
+              style={{ display: 'block', marginBottom: 6, fontSize: 14, fontWeight: 600 }}
+            >
+              キャラクター
+            </label>
+            <select
+              id="character-select"
+              value={characterFile}
+              onChange={(e) => setCharacterFile(e.target.value)}
               style={{
-                display: 'flex',
-                alignItems: 'center',
-                gap: 6,
+                width: '100%',
+                padding: '8px 12px',
                 fontSize: 14,
+                borderRadius: 6,
+                border: '1px solid #ccc',
+              }}
+            >
+              {CHARACTER_OPTIONS.map((opt) => (
+                <option key={opt.value} value={opt.value}>
+                  {opt.label}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <fieldset style={{ border: 'none', padding: 0, margin: '0 0 20px' }}>
+            <legend style={{ marginBottom: 6, fontSize: 14, fontWeight: 600, padding: 0 }}>
+              表示位置
+            </legend>
+            <div style={{ display: 'flex', gap: 24 }}>
+              {POSITION_OPTIONS.map((opt) => (
+                <label
+                  key={opt.value}
+                  style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 6,
+                    fontSize: 14,
+                    cursor: 'pointer',
+                  }}
+                >
+                  <input
+                    type="radio"
+                    name="displayPosition"
+                    value={opt.value}
+                    checked={displayPosition === opt.value}
+                    onChange={() => setDisplayPosition(opt.value)}
+                  />
+                  {opt.label}
+                </label>
+              ))}
+            </div>
+          </fieldset>
+
+          <div style={{ marginBottom: 24 }}>
+            <label
+              htmlFor="duration-input"
+              style={{ display: 'block', marginBottom: 6, fontSize: 14, fontWeight: 600 }}
+            >
+              表示時間（{MIN_DURATION}〜{MAX_DURATION}秒）
+            </label>
+            <input
+              id="duration-input"
+              type="number"
+              min={MIN_DURATION}
+              max={MAX_DURATION}
+              step={0.5}
+              value={displayDuration}
+              onChange={(e) => setDisplayDuration(Number(e.target.value))}
+              style={{
+                width: '100%',
+                padding: '8px 12px',
+                fontSize: 14,
+                borderRadius: 6,
+                border: '1px solid #ccc',
+                boxSizing: 'border-box',
+              }}
+            />
+            {isInvalid && (
+              <div style={{ marginTop: 4, fontSize: 12, color: '#e53935' }}>
+                {MIN_DURATION}〜{MAX_DURATION}秒の範囲で入力してください
+              </div>
+            )}
+          </div>
+
+          <button
+            type="button"
+            onClick={handleSave}
+            disabled={isInvalid}
+            style={{
+              padding: '8px 24px',
+              fontSize: 14,
+              borderRadius: 6,
+              border: 'none',
+              background: isInvalid ? '#ccc' : '#6B4EE6',
+              color: '#fff',
+              cursor: isInvalid ? 'default' : 'pointer',
+            }}
+          >
+            保存
+          </button>
+
+          {saved && (
+            <span style={{ marginLeft: 12, fontSize: 14, color: '#4CAF50' }}>保存しました</span>
+          )}
+        </div>
+      )}
+
+      {/* 通知履歴タブ */}
+      {activeTab === 'history' && (
+        <div
+          style={{
+            padding: '16px 24px',
+            display: 'flex',
+            flexDirection: 'column',
+            flex: 1,
+            minHeight: 0,
+          }}
+        >
+          <div
+            style={{
+              display: 'flex',
+              justifyContent: 'space-between',
+              alignItems: 'center',
+              marginBottom: 12,
+              flexShrink: 0,
+            }}
+          >
+            <span style={{ fontSize: 13, color: '#666' }}>最新30件（新しい順）</span>
+            <button
+              type="button"
+              onClick={() => setRefreshKey((k) => k + 1)}
+              style={{
+                padding: '4px 12px',
+                fontSize: 12,
+                borderRadius: 4,
+                border: '1px solid #6B4EE6',
+                background: 'none',
+                color: '#6B4EE6',
                 cursor: 'pointer',
               }}
             >
-              <input
-                type="radio"
-                name="displayPosition"
-                value={opt.value}
-                checked={displayPosition === opt.value}
-                onChange={() => setDisplayPosition(opt.value)}
-              />
-              {opt.label}
-            </label>
-          ))}
-        </div>
-      </fieldset>
-
-      <div style={{ marginBottom: 24 }}>
-        <label
-          htmlFor="duration-input"
-          style={{ display: 'block', marginBottom: 6, fontSize: 14, fontWeight: 600 }}
-        >
-          表示時間（{MIN_DURATION}〜{MAX_DURATION}秒）
-        </label>
-        <input
-          id="duration-input"
-          type="number"
-          min={MIN_DURATION}
-          max={MAX_DURATION}
-          step={0.5}
-          value={displayDuration}
-          onChange={(e) => setDisplayDuration(Number(e.target.value))}
-          style={{
-            width: '100%',
-            padding: '8px 12px',
-            fontSize: 14,
-            borderRadius: 6,
-            border: '1px solid #ccc',
-            boxSizing: 'border-box',
-          }}
-        />
-        {isInvalid && (
-          <div style={{ marginTop: 4, fontSize: 12, color: '#e53935' }}>
-            {MIN_DURATION}〜{MAX_DURATION}秒の範囲で入力してください
+              更新
+            </button>
           </div>
-        )}
-      </div>
 
-      <button
-        type="button"
-        onClick={handleSave}
-        disabled={isInvalid}
-        style={{
-          padding: '8px 24px',
-          fontSize: 14,
-          borderRadius: 6,
-          border: 'none',
-          background: isInvalid ? '#ccc' : '#6B4EE6',
-          color: '#fff',
-          cursor: isInvalid ? 'default' : 'pointer',
-        }}
-      >
-        保存
-      </button>
+          <div style={{ overflowY: 'auto', flex: 1 }}>
+            {historyState.status === 'loading' && (
+              <div style={{ textAlign: 'center', color: '#999', padding: 32, fontSize: 14 }}>
+                読み込み中...
+              </div>
+            )}
 
-      {saved && (
-        <span style={{ marginLeft: 12, fontSize: 14, color: '#4CAF50' }}>保存しました</span>
+            {historyState.status === 'error' && (
+              <div style={{ padding: 16 }}>
+                <div style={{ fontSize: 13, color: '#e53935', marginBottom: 8 }}>
+                  取得エラー: {historyState.message}
+                </div>
+                <button
+                  type="button"
+                  onClick={() => setRefreshKey((k) => k + 1)}
+                  style={{
+                    padding: '4px 12px',
+                    fontSize: 12,
+                    borderRadius: 4,
+                    border: '1px solid #ccc',
+                    background: 'none',
+                    cursor: 'pointer',
+                  }}
+                >
+                  再試行
+                </button>
+              </div>
+            )}
+
+            {historyState.status === 'success' && historyState.records.length === 0 && (
+              <div style={{ textAlign: 'center', color: '#999', padding: 32, fontSize: 14 }}>
+                通知履歴がありません
+              </div>
+            )}
+
+            {historyState.status === 'success' &&
+              historyState.records.map((record) => (
+                <div
+                  key={record.unixMs}
+                  style={{
+                    padding: '12px 14px',
+                    marginBottom: 8,
+                    borderRadius: 8,
+                    border: '1px solid #e8e4f8',
+                    background: '#fafafa',
+                  }}
+                >
+                  {/* アプリ名 + 通知ステータス + 日時 */}
+                  <div
+                    style={{
+                      display: 'flex',
+                      justifyContent: 'space-between',
+                      alignItems: 'center',
+                      marginBottom: record.sender !== record.appName || record.body ? 4 : 0,
+                    }}
+                  >
+                    <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+                      <span
+                        style={{
+                          fontSize: 11,
+                          color: '#888',
+                          fontWeight: 600,
+                        }}
+                      >
+                        {record.appName}
+                      </span>
+                      <span
+                        style={{
+                          fontSize: 10,
+                          padding: '1px 5px',
+                          borderRadius: 8,
+                          background: record.displayedByApp ? '#E8F5E9' : '#FFF3E0',
+                          color: record.displayedByApp ? '#388E3C' : '#E65100',
+                          fontWeight: 600,
+                        }}
+                      >
+                        {record.displayedByApp ? '通知済み' : '未通知'}
+                      </span>
+                    </div>
+                    <span style={{ fontSize: 11, color: '#bbb' }}>{record.timestamp}</span>
+                  </div>
+
+                  {/* タイトル（sender が appName と異なる場合のみ表示） */}
+                  {record.sender !== record.appName && (
+                    <div
+                      style={{
+                        fontSize: 13,
+                        fontWeight: 700,
+                        color: '#6B4EE6',
+                        marginBottom: record.body ? 4 : 0,
+                      }}
+                    >
+                      {record.sender}
+                    </div>
+                  )}
+
+                  {/* 本文 */}
+                  {record.body && (
+                    <div style={{ fontSize: 13, color: '#333', lineHeight: 1.5 }}>
+                      {record.body}
+                    </div>
+                  )}
+                </div>
+              ))}
+          </div>
+        </div>
       )}
     </div>
   );

--- a/src/renderer/src/electron.d.ts
+++ b/src/renderer/src/electron.d.ts
@@ -4,6 +4,17 @@ interface AppSettings {
   displayPosition: 'top-right' | 'bottom-right';
 }
 
+interface LatestNotificationRecord {
+  id: number;
+  timestamp: string;
+  unixMs: number;
+  sender: string;
+  body: string;
+  appName: string;
+  rawId: string;
+  displayedByApp: boolean;
+}
+
 interface ElectronAPI {
   onNotification: (
     callback: (data: { sender: string; body: string; appName?: string }) => void,
@@ -11,6 +22,8 @@ interface ElectronAPI {
   onSettingsChanged: (callback: (settings: AppSettings) => void) => () => void;
   getSettings: () => Promise<AppSettings>;
   saveSettings: (settings: AppSettings) => Promise<void>;
+  getNotificationHistory: () => Promise<LatestNotificationRecord[]>;
+  onNavigateTab: (callback: (tab: string) => void) => () => void;
 }
 
 interface Window {

--- a/src/renderer/src/main.tsx
+++ b/src/renderer/src/main.tsx
@@ -3,10 +3,14 @@ import ReactDOM from 'react-dom/client';
 import { CharacterOverlay } from './CharacterOverlay';
 import { SettingsApp } from './SettingsApp';
 
-const isSettings = window.location.hash === '#settings';
+const hash = window.location.hash;
+const isSettings = hash === '#settings' || hash === '#history';
+const initialTab = hash === '#history' ? 'history' : 'settings';
 
 const root = document.getElementById('root');
 if (!root) throw new Error('Root element not found');
 ReactDOM.createRoot(root).render(
-  <React.StrictMode>{isSettings ? <SettingsApp /> : <CharacterOverlay />}</React.StrictMode>,
+  <React.StrictMode>
+    {isSettings ? <SettingsApp initialTab={initialTab} /> : <CharacterOverlay />}
+  </React.StrictMode>,
 );


### PR DESCRIPTION
## Summary

- 設定ウィンドウを「設定」「通知履歴」の2タブ構成に変更し、issue #9 の通知履歴機能を実装
- トレイメニュー「最新30件を確認」を刷新し、設定ウィンドウの通知履歴タブを直接開くよう変更（ネイティブダイアログを廃止）
- 通知センターDB（最大40件）とアプリ表示済み履歴をマージし、最新30件をカード形式で表示
- 各通知カードに「通知済み」/「未通知」バッジを追加し、表示漏れをひと目で確認できるよう対応

## Changes

- `src/main/notificationHistory.ts`（新規）: 表示済み通知をインメモリキャッシュ＋非同期書き込みで永続化
- `src/main/monitors/base.ts` / `mac.ts` / `windows.ts`: `NotificationData` に `dbId`・`unixMs`・`rawId` を追加、`LatestNotificationRecord` に `unixMs`・`displayedByApp` を追加
- `src/main/index.ts`: 通知受信時に履歴保存、IPC ハンドラーでDB＋履歴マージ、設定ウィンドウのタブ切り替え対応
- `src/preload/index.ts` / `src/renderer/src/electron.d.ts`: 新 API（`getNotificationHistory`・`onNavigateTab`）を追加
- `src/renderer/src/SettingsApp.tsx`: タブUI・通知履歴カード・「通知済み」/「未通知」バッジを実装
- `src/renderer/src/main.tsx`: URL ハッシュで初期タブを判定

## Test plan

- [ ] トレイ「最新30件を確認」→ 設定ウィンドウが通知履歴タブで開く
- [ ] トレイ「設定」→ 設定ウィンドウが設定タブで開く
- [ ] 設定ウィンドウが開いている状態でトレイ「最新30件を確認」→ 通知履歴タブに切り替わる
- [ ] 通知履歴タブで最大30件のカードが表示される（日時・アプリ名・タイトル・本文）
- [ ] 通知を受信すると「通知済み」バッジが表示される
- [ ] 「更新」ボタンで再取得される
- [ ] エラー時に「再試行」ボタンが表示される

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)