### PR TITLE
fix: 通知履歴機能の回帰不具合を修正 (issue #21)

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -61,13 +61,19 @@ if (app.isReady()) {
 }
 
 import { addDisplayedNotification, getHistoryData } from './notificationHistory';
-import { type BaseNotificationMonitor, createNotificationMonitor } from './notificationMonitor';
+import {
+  type BaseNotificationMonitor,
+  createNotificationMonitor,
+  type NotificationData,
+} from './notificationMonitor';
 import { type AppSettings, loadSettings, saveSettings } from './settings';
 
 let overlayWindow: BrowserWindow | null = null;
 let settingsWindow: BrowserWindow | null = null;
 let tray: Tray | null = null;
 let monitor: BaseNotificationMonitor | null = null;
+
+const pendingNotifications = new Map<string, NotificationData>();
 
 const preloadPath = path.join(__dirname, '../preload/index.js');
 const rendererHtmlPath = path.join(__dirname, '../renderer/index.html');
@@ -221,6 +227,13 @@ app.whenReady().then(() => {
     const { x, y } = getOverlayPosition(settings);
     overlayWindow?.setPosition(x, y);
   });
+  ipcMain.handle('notification-displayed', (_event, dbId: string) => {
+    const pending = pendingNotifications.get(dbId);
+    if (pending) {
+      addDisplayedNotification(pending);
+      pendingNotifications.delete(dbId);
+    }
+  });
   ipcMain.handle('get-notification-history', async () => {
     const dbRecords = monitor ? await monitor.fetchLatest(40) : [];
     const dbIdSet = new Set(dbRecords.map((r) => String(r.id)));
@@ -257,8 +270,10 @@ app.whenReady().then(() => {
     });
   });
   monitor.on('notification', (notification) => {
+    if (notification.dbId) {
+      pendingNotifications.set(notification.dbId, notification);
+    }
     overlayWindow?.webContents.send('notification', notification);
-    addDisplayedNotification(notification);
   });
   monitor.on('permission-error', async () => {
     if (process.platform === 'darwin') {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -73,6 +73,7 @@ let settingsWindow: BrowserWindow | null = null;
 let tray: Tray | null = null;
 let monitor: BaseNotificationMonitor | null = null;
 
+const MAX_PENDING_NOTIFICATIONS = 50;
 const pendingNotifications = new Map<string, NotificationData>();
 
 const preloadPath = path.join(__dirname, '../preload/index.js');
@@ -272,6 +273,10 @@ app.whenReady().then(() => {
   monitor.on('notification', (notification) => {
     if (notification.dbId) {
       pendingNotifications.set(notification.dbId, notification);
+      if (pendingNotifications.size > MAX_PENDING_NOTIFICATIONS) {
+        const oldest = pendingNotifications.keys().next().value;
+        if (oldest !== undefined) pendingNotifications.delete(oldest);
+      }
     }
     overlayWindow?.webContents.send('notification', notification);
   });

--- a/src/main/notificationHistory.ts
+++ b/src/main/notificationHistory.ts
@@ -36,10 +36,15 @@ function getEntries(): DisplayedEntry[] {
   return cache;
 }
 
+let flushChain: Promise<void> = Promise.resolve();
+
 function flushAsync(): void {
-  fs.promises.writeFile(getHistoryPath(), JSON.stringify(cache ?? [])).catch((err) => {
-    console.error('Failed to save notification history:', err);
-  });
+  const snapshot = JSON.stringify(cache ?? []);
+  flushChain = flushChain
+    .then(() => fs.promises.writeFile(getHistoryPath(), snapshot))
+    .catch((err) => {
+      console.error('Failed to save notification history:', err);
+    });
 }
 
 export function addDisplayedNotification(data: {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -9,8 +9,9 @@ function createListener<T>(channel: string, callback: (data: T) => void): () => 
 }
 
 contextBridge.exposeInMainWorld('electronAPI', {
-  onNotification: (callback: (data: { sender: string; body: string; appName?: string }) => void) =>
-    createListener('notification', callback),
+  onNotification: (
+    callback: (data: { sender: string; body: string; appName?: string; dbId?: string }) => void,
+  ) => createListener('notification', callback),
   onSettingsChanged: (
     callback: (settings: {
       characterFile: string;
@@ -26,4 +27,5 @@ contextBridge.exposeInMainWorld('electronAPI', {
   }) => ipcRenderer.invoke('save-settings', settings),
   getNotificationHistory: () => ipcRenderer.invoke('get-notification-history'),
   onNavigateTab: (callback: (tab: string) => void) => createListener('navigate-tab', callback),
+  notificationDisplayed: (dbId: string) => ipcRenderer.invoke('notification-displayed', dbId),
 });

--- a/src/renderer/src/CharacterOverlay.tsx
+++ b/src/renderer/src/CharacterOverlay.tsx
@@ -46,10 +46,6 @@ export const CharacterOverlay: React.FC = () => {
     clearTimeout(displayTimerRef.current);
     clearTimeout(fadeTimerRef.current);
 
-    if (data.dbId) {
-      window.electronAPI.notificationDisplayed(data.dbId).catch(() => {});
-    }
-
     setNotification(data);
     setVisible(true);
     setFading(false);
@@ -72,6 +68,13 @@ export const CharacterOverlay: React.FC = () => {
       clearTimeout(fadeTimerRef.current);
     };
   }, [showNotification]);
+
+  // React commit 後に ack — バッチで描画されなかった通知は ack されない
+  useEffect(() => {
+    if (notification?.dbId) {
+      window.electronAPI.notificationDisplayed(notification.dbId).catch(() => {});
+    }
+  }, [notification]);
 
   if (!visible || !notification) return null;
 

--- a/src/renderer/src/CharacterOverlay.tsx
+++ b/src/renderer/src/CharacterOverlay.tsx
@@ -6,6 +6,7 @@ interface NotificationData {
   sender: string;
   body: string;
   appName?: string;
+  dbId?: string;
 }
 
 export const CharacterOverlay: React.FC = () => {
@@ -44,6 +45,10 @@ export const CharacterOverlay: React.FC = () => {
   const showNotification = useCallback((data: NotificationData) => {
     clearTimeout(displayTimerRef.current);
     clearTimeout(fadeTimerRef.current);
+
+    if (data.dbId) {
+      window.electronAPI.notificationDisplayed(data.dbId).catch(() => {});
+    }
 
     setNotification(data);
     setVisible(true);

--- a/src/renderer/src/SettingsApp.tsx
+++ b/src/renderer/src/SettingsApp.tsx
@@ -50,7 +50,10 @@ export const SettingsApp: React.FC<SettingsAppProps> = ({ initialTab = 'settings
   // メインプロセスからのタブ切り替えイベント
   useEffect(() => {
     return window.electronAPI.onNavigateTab((tab) => {
-      if (tab === 'settings' || tab === 'history') setActiveTab(tab as Tab);
+      if (tab === 'settings' || tab === 'history') {
+        setActiveTab(tab as Tab);
+        if (tab === 'history') setRefreshKey((k) => k + 1);
+      }
     });
   }, []);
 

--- a/src/renderer/src/electron.d.ts
+++ b/src/renderer/src/electron.d.ts
@@ -17,13 +17,14 @@ interface LatestNotificationRecord {
 
 interface ElectronAPI {
   onNotification: (
-    callback: (data: { sender: string; body: string; appName?: string }) => void,
+    callback: (data: { sender: string; body: string; appName?: string; dbId?: string }) => void,
   ) => () => void;
   onSettingsChanged: (callback: (settings: AppSettings) => void) => () => void;
   getSettings: () => Promise<AppSettings>;
   saveSettings: (settings: AppSettings) => Promise<void>;
   getNotificationHistory: () => Promise<LatestNotificationRecord[]>;
   onNavigateTab: (callback: (tab: string) => void) => () => void;
+  notificationDisplayed: (dbId: string) => Promise<void>;
 }
 
 interface Window {


### PR DESCRIPTION
## Summary

fixes #21

- **書き込み競合 (#1)**: `flushAsync` に promise チェーン (`flushChain`) を導入し、`writeFile` を直列化。スナップショットはチェーン登録前に取得するため、古い内容が後勝ちする問題を解消。
- **表示前記録 (#2)**: `pendingNotifications` マップを Main プロセスに追加。`'notification'` イベント受信時はマップに一時保存し、Renderer の `showNotification` 呼出時に `notification-displayed` IPC でアック → Main がマップからデータを取り出して永続化する方式に変更。
- **タブ再選択 no-op (#3)**: `onNavigateTab` ハンドラで `'history'` を受け取った際に `refreshKey` も必ずインクリメント。`activeTab` が既に `'history'` でも履歴フェッチ effect が再実行される。

## Test plan

- [ ] 3秒以内に複数通知を発生させ、`displayed-notifications.json` に全件記録されることを確認
- [ ] 設定ウィンドウの履歴タブを開いたまま、トレイ「最新30件を確認」を押すと一覧が更新されることを確認
- [ ] 通知がオーバーレイに表示された場合のみ「通知済み」バッジが付くことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)