### PR TITLE
fix: 通知履歴書き込み直列化 + 設定バリデーション (issue #23 優先度1・2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ out/
 dist/
 *.js.map
 .DS_Store
+.worktrees/

--- a/docs/superpowers/plans/2026-04-23-notification-history-settings-validation.md
+++ b/docs/superpowers/plans/2026-04-23-notification-history-settings-validation.md
@@ -1,0 +1,676 @@
+# 通知履歴書き込み直列化 + 設定バリデーション 実装プラン
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 通知履歴の非直列書き込みバグを修正し、設定バリデーションによるパストラバーサルリスクを排除する
+
+**Architecture:** `settings.ts` に `validateSettings()` を追加し load/save 両側で検証する。`notificationHistory.ts` は `writeChain` による直列化と atomic write (tmp→rename) を導入し、書き込み失敗フラグを IPC 経由で renderer に伝播する。
+
+**Tech Stack:** Node.js (fs.promises, rename), Electron IPC, React, Vitest
+
+---
+
+## ファイル構成
+
+| 操作 | ファイル | 変更内容 |
+|------|---------|---------|
+| Modify | `src/main/settings.ts` | `validateSettings` 追加、`loadSettings`/`saveSettings` 更新 |
+| Modify | `src/main/settings.test.ts` | `validateSettings` テスト追加、`saveSettings` throw テスト追加 |
+| Modify | `src/main/notificationHistory.ts` | `writeChain` 直列化、atomic write、`writeError` フラグ、`flushNotificationHistory` export |
+| Create | `src/main/notificationHistory.test.ts` | 直列化・atomic・writeError の Unit テスト |
+| Modify | `src/main/index.ts` | `get-notification-history` ハンドラの戻り値に `writeError` 追加 |
+| Modify | `src/renderer/src/electron.d.ts` | `getNotificationHistory` 戻り値型更新 |
+| Modify | `src/renderer/src/SettingsApp.tsx` | `saveError` state、`handleSave` try/catch、`writeError` バナー |
+
+---
+
+## Task 1: `validateSettings` の実装 (TDD)
+
+**Files:**
+- Modify: `src/main/settings.ts`
+- Modify: `src/main/settings.test.ts`
+
+- [ ] **Step 1: `settings.test.ts` に失敗するテストを追加する**
+
+既存の `import { loadSettings, saveSettings } from './settings';` を以下に差し替える。
+
+```typescript
+import { loadSettings, saveSettings, validateSettings } from './settings';
+```
+
+ファイル末尾に以下のテストを追加する。
+
+```typescript
+describe('validateSettings', () => {
+  it('returns valid settings unchanged', () => {
+    expect(
+      validateSettings({
+        characterFile: 'crab.json',
+        displayDuration: 3000,
+        displayPosition: 'bottom-right',
+      }),
+    ).toEqual({
+      characterFile: 'crab.json',
+      displayDuration: 3000,
+      displayPosition: 'bottom-right',
+    });
+  });
+
+  it('falls back to default characterFile for path traversal attempt', () => {
+    expect(validateSettings({ characterFile: '../../etc/passwd' })).toMatchObject({
+      characterFile: 'dance.json',
+    });
+  });
+
+  it('falls back to default characterFile for unknown file', () => {
+    expect(validateSettings({ characterFile: 'custom.json' })).toMatchObject({
+      characterFile: 'dance.json',
+    });
+  });
+
+  it('clamps displayDuration below 1000 to 1000', () => {
+    expect(validateSettings({ displayDuration: 100 })).toMatchObject({
+      displayDuration: 1000,
+    });
+  });
+
+  it('clamps displayDuration above 60000 to 60000', () => {
+    expect(validateSettings({ displayDuration: 999999 })).toMatchObject({
+      displayDuration: 60000,
+    });
+  });
+
+  it('falls back to default displayDuration for non-number', () => {
+    expect(validateSettings({ displayDuration: 'fast' })).toMatchObject({
+      displayDuration: 5000,
+    });
+  });
+
+  it('falls back to default displayPosition for invalid value', () => {
+    expect(validateSettings({ displayPosition: 'center' })).toMatchObject({
+      displayPosition: 'top-right',
+    });
+  });
+
+  it('fills missing fields with defaults', () => {
+    expect(validateSettings({})).toEqual({
+      characterFile: 'dance.json',
+      displayDuration: 5000,
+      displayPosition: 'top-right',
+    });
+  });
+});
+```
+
+`saveSettings` の `describe` ブロックに以下を追加する。
+
+```typescript
+  it('throws when characterFile is not in the allowed list', () => {
+    expect(() =>
+      saveSettings({
+        characterFile: '../../malicious.json',
+        displayDuration: 5000,
+        displayPosition: 'top-right',
+      }),
+    ).toThrow('Invalid characterFile');
+  });
+```
+
+- [ ] **Step 2: テストが失敗することを確認する**
+
+```bash
+npm test -- --reporter=verbose src/main/settings.test.ts
+```
+
+Expected: `validateSettings is not a function` または `throw` テストが FAIL
+
+- [ ] **Step 3: `settings.ts` に `validateSettings` を追加し、`loadSettings`/`saveSettings` を更新する**
+
+`src/main/settings.ts` を以下の内容に全て置き換える。
+
+```typescript
+import fs from 'node:fs';
+import path from 'node:path';
+import { app } from 'electron';
+
+export interface AppSettings {
+  characterFile: string;
+  displayDuration: number;
+  displayPosition: 'top-right' | 'bottom-right';
+}
+
+const DEFAULT_SETTINGS: AppSettings = {
+  characterFile: 'dance.json',
+  displayDuration: 5000,
+  displayPosition: 'top-right',
+};
+
+const ALLOWED_CHARACTER_FILES: readonly string[] = ['dance.json', 'crab.json'];
+const ALLOWED_DISPLAY_POSITIONS: readonly string[] = ['top-right', 'bottom-right'];
+
+function settingsPath(): string {
+  return path.join(app.getPath('userData'), 'settings.json');
+}
+
+export function validateSettings(raw: unknown): AppSettings {
+  const r = (raw ?? {}) as Record<string, unknown>;
+
+  const characterFile =
+    typeof r.characterFile === 'string' && ALLOWED_CHARACTER_FILES.includes(r.characterFile)
+      ? r.characterFile
+      : DEFAULT_SETTINGS.characterFile;
+
+  let displayDuration = DEFAULT_SETTINGS.displayDuration;
+  if (typeof r.displayDuration === 'number' && !Number.isNaN(r.displayDuration)) {
+    displayDuration = Math.min(60000, Math.max(1000, r.displayDuration));
+  }
+
+  const displayPosition =
+    typeof r.displayPosition === 'string' && ALLOWED_DISPLAY_POSITIONS.includes(r.displayPosition)
+      ? (r.displayPosition as AppSettings['displayPosition'])
+      : DEFAULT_SETTINGS.displayPosition;
+
+  return { characterFile, displayDuration, displayPosition };
+}
+
+export function loadSettings(): AppSettings {
+  try {
+    const raw = fs.readFileSync(settingsPath(), 'utf-8');
+    const parsed = JSON.parse(raw) as unknown;
+    return validateSettings(parsed);
+  } catch {
+    return { ...DEFAULT_SETTINGS };
+  }
+}
+
+export function saveSettings(settings: AppSettings): void {
+  if (!ALLOWED_CHARACTER_FILES.includes(settings.characterFile)) {
+    throw new Error(`Invalid characterFile: ${settings.characterFile}`);
+  }
+  const validated = validateSettings(settings);
+  fs.writeFileSync(settingsPath(), JSON.stringify(validated, null, 2), 'utf-8');
+}
+```
+
+- [ ] **Step 4: テストが全て通ることを確認する**
+
+```bash
+npm test -- --reporter=verbose src/main/settings.test.ts
+```
+
+Expected: 全テスト PASS（既存テストも含む）
+
+- [ ] **Step 5: コミットする**
+
+```bash
+git add src/main/settings.ts src/main/settings.test.ts
+git commit -m "feat: settings バリデーション追加（characterFile whitelist + displayDuration clamp）"
+```
+
+---
+
+## Task 2: Renderer の保存エラー表示
+
+**Files:**
+- Modify: `src/renderer/src/SettingsApp.tsx`
+
+- [ ] **Step 1: `saveError` state を追加し `handleSave` を try/catch で囲む**
+
+`SettingsApp.tsx` の `const [saved, setSaved] = useState(false);` の直後に以下を追加する。
+
+```typescript
+  const [saveError, setSaveError] = useState<string | null>(null);
+```
+
+`handleSave` 関数全体を以下に置き換える。
+
+```typescript
+  const handleSave = async () => {
+    try {
+      await window.electronAPI.saveSettings({
+        characterFile,
+        displayDuration: displayDuration * 1000,
+        displayPosition,
+      });
+      setSaved(true);
+      setSaveError(null);
+      setTimeout(() => setSaved(false), 2000);
+    } catch (err) {
+      setSaveError(String(err));
+    }
+  };
+```
+
+- [ ] **Step 2: 保存ボタン直後にエラー表示を追加する**
+
+`SettingsApp.tsx` の `{saved && (...)}` の直後に以下を追加する。
+
+```tsx
+          {saveError && (
+            <div style={{ marginTop: 8, fontSize: 13, color: '#e53935' }}>
+              {saveError}
+            </div>
+          )}
+```
+
+- [ ] **Step 3: ビルドが通ることを確認する**
+
+```bash
+npm run build 2>&1 | tail -20
+```
+
+Expected: エラーなし
+
+- [ ] **Step 4: コミットする**
+
+```bash
+git add src/renderer/src/SettingsApp.tsx
+git commit -m "feat: 設定保存失敗時にエラーメッセージを表示"
+```
+
+---
+
+## Task 3: 通知履歴書き込みの直列化 + Atomic write (TDD)
+
+**Files:**
+- Create: `src/main/notificationHistory.test.ts`
+- Modify: `src/main/notificationHistory.ts`
+
+- [ ] **Step 1: 失敗するテストファイルを作成する**
+
+`src/main/notificationHistory.test.ts` を新規作成する。
+
+```typescript
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: vi.fn(() => '/tmp/mascot-test'),
+  },
+}));
+
+const readFileSyncMock = vi.fn();
+const writeFileMock = vi.fn();
+const renameMock = vi.fn();
+
+vi.mock('node:fs', () => ({
+  default: {
+    readFileSync: (...args: unknown[]) => readFileSyncMock(...args),
+    promises: {
+      writeFile: (...args: unknown[]) => writeFileMock(...args),
+      rename: (...args: unknown[]) => renameMock(...args),
+    },
+  },
+}));
+
+import {
+  _resetStateForTesting,
+  addDisplayedNotification,
+  flushNotificationHistory,
+  getHistoryData,
+} from './notificationHistory';
+
+describe('notificationHistory', () => {
+  beforeEach(() => {
+    _resetStateForTesting();
+    readFileSyncMock.mockReset();
+    writeFileMock.mockReset();
+    renameMock.mockReset();
+    readFileSyncMock.mockImplementation(() => {
+      throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+    });
+    writeFileMock.mockResolvedValue(undefined);
+    renameMock.mockResolvedValue(undefined);
+  });
+
+  describe('addDisplayedNotification', () => {
+    it('ignores entries without dbId', async () => {
+      addDisplayedNotification({ sender: 'Alice', body: 'Hello' });
+      await flushNotificationHistory();
+      expect(writeFileMock).not.toHaveBeenCalled();
+    });
+
+    it('deduplicates entries with the same dbId', async () => {
+      addDisplayedNotification({ dbId: '1', sender: 'Alice', body: 'Hello' });
+      addDisplayedNotification({ dbId: '1', sender: 'Alice', body: 'Hello again' });
+      await flushNotificationHistory();
+      const lastCall = writeFileMock.mock.calls[writeFileMock.mock.calls.length - 1];
+      const written = JSON.parse(lastCall[1] as string) as unknown[];
+      expect(written).toHaveLength(1);
+    });
+
+    it('serializes concurrent writes so the latest snapshot is written last', async () => {
+      let resolveFirst!: () => void;
+      writeFileMock
+        .mockImplementationOnce(() => new Promise<void>((r) => { resolveFirst = r; }))
+        .mockResolvedValue(undefined);
+
+      addDisplayedNotification({ dbId: '1', sender: 'Alice', body: 'Hello' });
+      addDisplayedNotification({ dbId: '2', sender: 'Bob', body: 'World' });
+
+      resolveFirst();
+      await flushNotificationHistory();
+
+      expect(writeFileMock).toHaveBeenCalledTimes(2);
+      const lastWrite = JSON.parse(writeFileMock.mock.calls[1][1] as string) as Array<{ dbId: string }>;
+      expect(lastWrite).toHaveLength(2);
+      expect(lastWrite[0].dbId).toBe('2');
+      expect(lastWrite[1].dbId).toBe('1');
+    });
+
+    it('writes to a tmp file and renames to the final path (atomic write)', async () => {
+      addDisplayedNotification({ dbId: '1', sender: 'Alice', body: 'Hello' });
+      await flushNotificationHistory();
+
+      const tmpPath = writeFileMock.mock.calls[0][0] as string;
+      const [renameSrc, renameDst] = renameMock.mock.calls[0] as [string, string];
+      expect(tmpPath).toBe('/tmp/mascot-test/displayed-notifications.json.tmp');
+      expect(renameSrc).toBe('/tmp/mascot-test/displayed-notifications.json.tmp');
+      expect(renameDst).toBe('/tmp/mascot-test/displayed-notifications.json');
+    });
+  });
+
+  describe('writeError flag', () => {
+    it('sets writeError to true when writeFile throws', async () => {
+      writeFileMock.mockRejectedValue(new Error('disk full'));
+      addDisplayedNotification({ dbId: '1', sender: 'Alice', body: 'Hello' });
+      await flushNotificationHistory();
+      expect(getHistoryData(new Set()).writeError).toBe(true);
+    });
+
+    it('clears writeError after a subsequent successful write', async () => {
+      writeFileMock.mockRejectedValueOnce(new Error('disk full'));
+      addDisplayedNotification({ dbId: '1', sender: 'Alice', body: 'Hello' });
+      await flushNotificationHistory();
+      expect(getHistoryData(new Set()).writeError).toBe(true);
+
+      addDisplayedNotification({ dbId: '2', sender: 'Bob', body: 'World' });
+      await flushNotificationHistory();
+      expect(getHistoryData(new Set()).writeError).toBe(false);
+    });
+  });
+});
+```
+
+- [ ] **Step 2: テストが失敗することを確認する**
+
+```bash
+npm test -- --reporter=verbose src/main/notificationHistory.test.ts
+```
+
+Expected: `_resetStateForTesting is not a function` または `flushNotificationHistory is not a function` で FAIL
+
+- [ ] **Step 3: `notificationHistory.ts` を更新する**
+
+`src/main/notificationHistory.ts` を以下の内容に全て置き換える。
+
+```typescript
+import fs from 'node:fs';
+import path from 'node:path';
+import { app } from 'electron';
+import { formatNotificationTimestamp } from './monitors/base';
+
+interface DisplayedEntry {
+  dbId: string;
+  unixMs: number;
+  timestamp: string;
+  sender: string;
+  body: string;
+  appName: string;
+  rawId: string;
+}
+
+export interface HistoryData {
+  displayedIds: Set<string>;
+  historyOnly: DisplayedEntry[];
+  writeError: boolean;
+}
+
+const MAX_ENTRIES = 200;
+let cache: DisplayedEntry[] | null = null;
+let writeChain: Promise<void> = Promise.resolve();
+let lastWriteError = false;
+
+function getHistoryPath(): string {
+  return path.join(app.getPath('userData'), 'displayed-notifications.json');
+}
+
+function getEntries(): DisplayedEntry[] {
+  if (cache === null) {
+    try {
+      cache = JSON.parse(fs.readFileSync(getHistoryPath(), 'utf-8')) as DisplayedEntry[];
+    } catch {
+      cache = [];
+    }
+  }
+  return cache;
+}
+
+function flushAsync(): void {
+  const snapshot = JSON.stringify(cache ?? []);
+  const target = getHistoryPath();
+  const tmp = `${target}.tmp`;
+
+  writeChain = writeChain
+    .then(() => fs.promises.writeFile(tmp, snapshot))
+    .then(() => fs.promises.rename(tmp, target))
+    .then(() => {
+      lastWriteError = false;
+    })
+    .catch((err) => {
+      lastWriteError = true;
+      console.error('Failed to save notification history:', err);
+    });
+}
+
+export function flushNotificationHistory(): Promise<void> {
+  return writeChain;
+}
+
+export function addDisplayedNotification(data: {
+  dbId?: string;
+  unixMs?: number;
+  sender: string;
+  body: string;
+  appName?: string;
+  rawId?: string;
+}): void {
+  if (!data.dbId) return;
+
+  const entries = getEntries();
+  if (entries.some((e) => e.dbId === data.dbId)) return;
+
+  const unixMs = data.unixMs ?? Date.now();
+  entries.unshift({
+    dbId: data.dbId,
+    unixMs,
+    timestamp: formatNotificationTimestamp(unixMs),
+    sender: data.sender,
+    body: data.body,
+    appName: data.appName ?? '',
+    rawId: data.rawId ?? '',
+  });
+
+  if (entries.length > MAX_ENTRIES) {
+    entries.splice(MAX_ENTRIES);
+  }
+
+  flushAsync();
+}
+
+export function getHistoryData(dbIdSet: Set<string>): HistoryData {
+  const entries = getEntries();
+  return {
+    displayedIds: new Set(entries.map((e) => e.dbId)),
+    historyOnly: entries.filter((e) => !dbIdSet.has(e.dbId)),
+    writeError: lastWriteError,
+  };
+}
+
+export function _resetStateForTesting(): void {
+  cache = null;
+  writeChain = Promise.resolve();
+  lastWriteError = false;
+}
+```
+
+- [ ] **Step 4: テストが全て通ることを確認する**
+
+```bash
+npm test -- --reporter=verbose src/main/notificationHistory.test.ts
+```
+
+Expected: 全テスト PASS
+
+- [ ] **Step 5: コミットする**
+
+```bash
+git add src/main/notificationHistory.ts src/main/notificationHistory.test.ts
+git commit -m "feat: 通知履歴書き込みを直列化し atomic write を導入"
+```
+
+---
+
+## Task 4: `writeError` の IPC 伝播と履歴タブへのバナー表示
+
+**Files:**
+- Modify: `src/main/index.ts`
+- Modify: `src/renderer/src/electron.d.ts`
+- Modify: `src/renderer/src/SettingsApp.tsx`
+
+- [ ] **Step 1: `index.ts` の `get-notification-history` ハンドラを更新する**
+
+`ipcMain.handle('get-notification-history', ...)` の `return` 文を以下に変更する。
+
+変更前:
+```typescript
+    return [...markedDbRecords, ...historyOnlyRecords]
+      .sort((a, b) => b.unixMs - a.unixMs)
+      .slice(0, 30);
+```
+
+変更後:
+```typescript
+    return {
+      records: [...markedDbRecords, ...historyOnlyRecords]
+        .sort((a, b) => b.unixMs - a.unixMs)
+        .slice(0, 30),
+      writeError,
+    };
+```
+
+同ハンドラ内の `const { displayedIds, historyOnly } = getHistoryData(dbIdSet);` を以下に変更する。
+
+```typescript
+    const { displayedIds, historyOnly, writeError } = getHistoryData(dbIdSet);
+```
+
+- [ ] **Step 2: `electron.d.ts` の `getNotificationHistory` 戻り値型を更新する**
+
+`src/renderer/src/electron.d.ts` の `getNotificationHistory` の行を以下に変更する。
+
+変更前:
+```typescript
+  getNotificationHistory: () => Promise<LatestNotificationRecord[]>;
+```
+
+変更後:
+```typescript
+  getNotificationHistory: () => Promise<{ records: LatestNotificationRecord[]; writeError: boolean }>;
+```
+
+- [ ] **Step 3: `SettingsApp.tsx` の `HistoryState` 型を更新し、getNotificationHistory 呼び出しを修正する**
+
+`HistoryState` 型を以下に変更する。
+
+変更前:
+```typescript
+type HistoryState =
+  | { status: 'idle' }
+  | { status: 'loading' }
+  | { status: 'success'; records: LatestNotificationRecord[] }
+  | { status: 'error'; message: string };
+```
+
+変更後:
+```typescript
+type HistoryState =
+  | { status: 'idle' }
+  | { status: 'loading' }
+  | { status: 'success'; records: LatestNotificationRecord[]; writeError: boolean }
+  | { status: 'error'; message: string };
+```
+
+`getNotificationHistory()` の `.then()` を以下に変更する。
+
+変更前:
+```typescript
+      .then((records) => setHistoryState({ status: 'success', records }))
+```
+
+変更後:
+```typescript
+      .then(({ records, writeError }) =>
+        setHistoryState({ status: 'success', records, writeError }),
+      )
+```
+
+- [ ] **Step 4: 履歴タブに writeError バナーを追加する**
+
+`SettingsApp.tsx` の `<div style={{ overflowY: 'auto', flex: 1 }}>` の直後（`{historyState.status === 'loading' && ...}` の前）に以下を追加する。
+
+```tsx
+            {historyState.status === 'success' && historyState.writeError && (
+              <div
+                style={{
+                  padding: '6px 12px',
+                  marginBottom: 8,
+                  borderRadius: 4,
+                  background: '#FFF3E0',
+                  color: '#E65100',
+                  fontSize: 12,
+                }}
+              >
+                履歴の保存に失敗しました
+              </div>
+            )}
+```
+
+- [ ] **Step 5: ビルドと全テストが通ることを確認する**
+
+```bash
+npm run build 2>&1 | tail -20
+```
+
+```bash
+npm test 2>&1 | tail -30
+```
+
+Expected: ビルドエラーなし、全テスト PASS
+
+- [ ] **Step 6: コミットする**
+
+```bash
+git add src/main/index.ts src/renderer/src/electron.d.ts src/renderer/src/SettingsApp.tsx
+git commit -m "feat: writeError フラグを IPC 経由で伝播し履歴タブにバナー表示"
+```
+
+---
+
+## 最終確認
+
+- [ ] **全テスト実行**
+
+```bash
+npm test
+```
+
+Expected: 全テスト PASS
+
+- [ ] **lint チェック**
+
+```bash
+npm run lint
+```
+
+Expected: エラーなし

--- a/docs/superpowers/specs/2026-04-23-notification-history-and-settings-validation-design.md
+++ b/docs/superpowers/specs/2026-04-23-notification-history-and-settings-validation-design.md
@@ -1,0 +1,164 @@
+# 設計書: 通知履歴書き込み直列化 + 設定バリデーション
+
+**日付:** 2026-04-23
+**対象Issue:** #23（優先度1・2）
+
+---
+
+## 背景
+
+GitHub Issue #23 のレビュー結果として以下の2点を対応する。
+
+1. **通知履歴の非直列書き込み（Item 1）**: `flushAsync()` が `fs.promises.writeFile` を await せずキューイングもしていないため、複数の write が並走すると古いスナップショットが後から書き込まれて最新履歴が失われる。
+2. **設定値のスキーマ検証欠如（Item 2）**: `characterFile` がファイルパス構築に使われているにもかかわらずバリデーションがなく、パストラバーサルのリスクがある。`displayDuration` や `displayPosition` の不正値も無検証で保存される。
+
+---
+
+## Item 1: 通知履歴書き込みの直列化 + Atomic write
+
+### 変更ファイル
+- `src/main/notificationHistory.ts`
+- `src/main/index.ts`
+- `src/renderer/src/SettingsApp.tsx`
+
+### 設計
+
+#### `src/main/notificationHistory.ts`
+
+モジュールレベルに以下を追加する。
+
+```typescript
+let writeChain: Promise<void> = Promise.resolve();
+let lastWriteError = false;
+```
+
+`flushAsync()` を以下のように変更する。
+
+```typescript
+function flushAsync(): void {
+  const snapshot = JSON.stringify(cache ?? []);
+  const target = getHistoryPath();
+  const tmp = target + '.tmp';
+
+  writeChain = writeChain
+    .then(() => fs.promises.writeFile(tmp, snapshot))
+    .then(() => fs.promises.rename(tmp, target))
+    .then(() => { lastWriteError = false; })
+    .catch((err) => {
+      lastWriteError = true;
+      console.error('Failed to save notification history:', err);
+    });
+}
+```
+
+`HistoryData` 型に `writeError: boolean` を追加する。
+
+```typescript
+export interface HistoryData {
+  displayedIds: Set<string>;
+  historyOnly: DisplayedEntry[];
+  writeError: boolean;
+}
+```
+
+`getHistoryData()` の戻り値に `writeError: lastWriteError` を追加する。
+
+#### `src/main/index.ts`
+
+`get-notification-history` ハンドラで `writeError` をレスポンスに含める。現在のフラット配列返しから以下に変更する。
+
+```typescript
+return {
+  records: [...markedDbRecords, ...historyOnlyRecords].sort(...).slice(0, 30),
+  writeError: writeError,
+};
+```
+
+#### `src/renderer/src/electron.d.ts`
+
+`getNotificationHistory` の戻り値型を更新する。
+
+```typescript
+getNotificationHistory: () => Promise<{ records: LatestNotificationRecord[]; writeError: boolean }>;
+```
+
+#### `src/renderer/src/SettingsApp.tsx`
+
+`HistoryState` 型の `success` バリアントに `writeError` を追加する。
+
+```typescript
+type HistoryState =
+  | { status: 'idle' }
+  | { status: 'loading' }
+  | { status: 'success'; records: LatestNotificationRecord[]; writeError: boolean }
+  | { status: 'error'; message: string };
+```
+
+`getNotificationHistory()` の `.then()` を更新してレスポンス構造の変化に対応する。
+
+```typescript
+.then(({ records, writeError }) =>
+  setHistoryState({ status: 'success', records, writeError })
+)
+```
+
+`writeError` が `true` のとき、履歴リストの上部にバナーを表示する。
+
+```
+「履歴の保存に失敗しました」
+```
+
+### 動作保証
+
+- `snapshot` は `flushAsync()` 呼び出し時点で文字列化するため、チェーン実行タイミングに関わらず最新状態を持つ
+- `writeChain` によって前の write が完了してから次が始まるため、逆順完了による上書きが起きない
+- `tmp → rename` で atomic write を実現し、書き込み途中のクラッシュで既存ファイルが壊れない
+- エラーは `.catch` で吸収してチェーンが詰まらないようにする
+
+---
+
+## Item 2: 設定値のバリデーション
+
+### 変更ファイル
+- `src/main/settings.ts`
+- `src/main/index.ts`
+- `src/renderer/src/SettingsApp.tsx`
+
+### 設計
+
+#### `src/main/settings.ts`
+
+`validateSettings(raw: unknown): AppSettings` 関数を追加する。
+
+| フィールド | バリデーション | 不正時の挙動 |
+|---|---|---|
+| `characterFile` | `['dance.json', 'crab.json']` のみ許可 | `DEFAULT_SETTINGS.characterFile` にフォールバック |
+| `displayDuration` | 数値 かつ `1000〜60000ms` の範囲内 | 範囲外は clamp、数値でなければデフォルト値 |
+| `displayPosition` | `'top-right'` または `'bottom-right'` のみ | `DEFAULT_SETTINGS.displayPosition` にフォールバック |
+
+`loadSettings()` — `JSON.parse` 後に `validateSettings()` を通す（起動時の壊れた設定を自動修復）。
+
+`saveSettings(settings: AppSettings): void` — 保存前に `characterFile` が許可リストにない場合は `throw new Error('Invalid characterFile')` する。その他のフィールドは `validateSettings()` を通して正規化してから保存する。
+
+#### `src/main/index.ts`
+
+`ipcMain.handle` は `throw` を自動的に IPC エラーとして renderer に伝播するため、`save-settings` ハンドラへの追加実装は不要。
+
+#### `src/renderer/src/SettingsApp.tsx`
+
+- `saveError: string | null` の state を追加する
+- `handleSave` を `try/catch` で囲み、エラー時に `saveError` をセットして設定フォーム内に表示する
+- 保存成功時は `saveError` をクリアする
+
+---
+
+## テスト方針
+
+- `notificationHistory.ts`: `addDisplayedNotification` を連続呼び出しして、`displayed-notifications.json` の最終状態が最新であることを検証するユニットテストを追加
+- `settings.ts`: `validateSettings()` に対して各フィールドの境界値・不正値を網羅するユニットテストを追加
+
+---
+
+## スコープ外
+
+- Item 3（プライバシー説明）、Item 4（型共通化）、Item 5（public suffix）、Item 6（CI）は本設計書の対象外

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,9 @@
         "typescript": "^5.7.0",
         "vite": "^6.0.0",
         "vitest": "^4.1.4"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -216,9 +216,9 @@ app.whenReady().then(() => {
 
   ipcMain.handle('get-settings', () => loadSettings());
   ipcMain.handle('save-settings', (_event, settings: AppSettings) => {
-    saveSettings(settings);
-    overlayWindow?.webContents.send('settings-changed', settings);
-    const { x, y } = getOverlayPosition(settings);
+    const validated = saveSettings(settings);
+    overlayWindow?.webContents.send('settings-changed', validated);
+    const { x, y } = getOverlayPosition(validated);
     overlayWindow?.setPosition(x, y);
   });
   ipcMain.handle('get-notification-history', async () => {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -60,7 +60,11 @@ if (app.isReady()) {
   app.whenReady().then(initFileLogging);
 }
 
-import { addDisplayedNotification, getHistoryData } from './notificationHistory';
+import {
+  addDisplayedNotification,
+  getHistoryData,
+  setWriteErrorCallback,
+} from './notificationHistory';
 import { type BaseNotificationMonitor, createNotificationMonitor } from './notificationMonitor';
 import { type AppSettings, loadSettings, saveSettings } from './settings';
 
@@ -213,6 +217,10 @@ function createTray(): void {
 app.whenReady().then(() => {
   overlayWindow = createOverlayWindow();
   createTray();
+
+  setWriteErrorCallback((hasError) => {
+    settingsWindow?.webContents.send('history-write-error', hasError);
+  });
 
   ipcMain.handle('get-settings', () => loadSettings());
   ipcMain.handle('save-settings', (_event, settings: AppSettings) => {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -225,7 +225,7 @@ app.whenReady().then(() => {
     const dbRecords = monitor ? await monitor.fetchLatest(40) : [];
     const dbIdSet = new Set(dbRecords.map((r) => String(r.id)));
 
-    const { displayedIds, historyOnly } = getHistoryData(dbIdSet);
+    const { displayedIds, historyOnly, writeError } = getHistoryData(dbIdSet);
 
     const markedDbRecords = dbRecords.map((r) => ({
       ...r,
@@ -243,9 +243,12 @@ app.whenReady().then(() => {
       displayedByApp: true as const,
     }));
 
-    return [...markedDbRecords, ...historyOnlyRecords]
-      .sort((a, b) => b.unixMs - a.unixMs)
-      .slice(0, 30);
+    return {
+      records: [...markedDbRecords, ...historyOnlyRecords]
+        .sort((a, b) => b.unixMs - a.unixMs)
+        .slice(0, 30),
+      writeError,
+    };
   });
 
   monitor = createNotificationMonitor();

--- a/src/main/notificationHistory.test.ts
+++ b/src/main/notificationHistory.test.ts
@@ -1,0 +1,120 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: vi.fn(() => '/tmp/mascot-test'),
+  },
+}));
+
+const readFileSyncMock = vi.fn();
+const writeFileMock = vi.fn();
+const renameMock = vi.fn();
+
+vi.mock('node:fs', () => ({
+  default: {
+    readFileSync: (...args: unknown[]) => readFileSyncMock(...args),
+    promises: {
+      writeFile: (...args: unknown[]) => writeFileMock(...args),
+      rename: (...args: unknown[]) => renameMock(...args),
+    },
+  },
+}));
+
+import {
+  _resetStateForTesting,
+  addDisplayedNotification,
+  flushNotificationHistory,
+  getHistoryData,
+} from './notificationHistory';
+
+describe('notificationHistory', () => {
+  beforeEach(() => {
+    _resetStateForTesting();
+    readFileSyncMock.mockReset();
+    writeFileMock.mockReset();
+    renameMock.mockReset();
+    readFileSyncMock.mockImplementation(() => {
+      throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+    });
+    writeFileMock.mockResolvedValue(undefined);
+    renameMock.mockResolvedValue(undefined);
+  });
+
+  describe('addDisplayedNotification', () => {
+    it('ignores entries without dbId', async () => {
+      addDisplayedNotification({ sender: 'Alice', body: 'Hello' });
+      await flushNotificationHistory();
+      expect(writeFileMock).not.toHaveBeenCalled();
+    });
+
+    it('deduplicates entries with the same dbId', async () => {
+      addDisplayedNotification({ dbId: '1', sender: 'Alice', body: 'Hello' });
+      addDisplayedNotification({ dbId: '1', sender: 'Alice', body: 'Hello again' });
+      await flushNotificationHistory();
+      const lastCall = writeFileMock.mock.calls[writeFileMock.mock.calls.length - 1];
+      const written = JSON.parse(lastCall[1] as string) as unknown[];
+      expect(written).toHaveLength(1);
+    });
+
+    it('serializes concurrent writes so the latest snapshot is written last', async () => {
+      let resolveFirst: (() => void) | undefined;
+      writeFileMock
+        .mockImplementationOnce(
+          () =>
+            new Promise<void>((r) => {
+              resolveFirst = r;
+            }),
+        )
+        .mockResolvedValue(undefined);
+
+      addDisplayedNotification({ dbId: '1', sender: 'Alice', body: 'Hello' });
+      // Yield to allow the first write to be queued
+      await new Promise((resolve) => setImmediate(resolve));
+      addDisplayedNotification({ dbId: '2', sender: 'Bob', body: 'World' });
+
+      if (resolveFirst) {
+        resolveFirst();
+      }
+      await flushNotificationHistory();
+
+      expect(writeFileMock).toHaveBeenCalledTimes(2);
+      const lastWrite = JSON.parse(writeFileMock.mock.calls[1][1] as string) as Array<{
+        dbId: string;
+      }>;
+      expect(lastWrite).toHaveLength(2);
+      expect(lastWrite[0].dbId).toBe('2');
+      expect(lastWrite[1].dbId).toBe('1');
+    });
+
+    it('writes to a tmp file and renames to the final path (atomic write)', async () => {
+      addDisplayedNotification({ dbId: '1', sender: 'Alice', body: 'Hello' });
+      await flushNotificationHistory();
+
+      const tmpPath = writeFileMock.mock.calls[0][0] as string;
+      const [renameSrc, renameDst] = renameMock.mock.calls[0] as [string, string];
+      expect(tmpPath).toBe('/tmp/mascot-test/displayed-notifications.json.tmp');
+      expect(renameSrc).toBe('/tmp/mascot-test/displayed-notifications.json.tmp');
+      expect(renameDst).toBe('/tmp/mascot-test/displayed-notifications.json');
+    });
+  });
+
+  describe('writeError flag', () => {
+    it('sets writeError to true when writeFile throws', async () => {
+      writeFileMock.mockRejectedValue(new Error('disk full'));
+      addDisplayedNotification({ dbId: '1', sender: 'Alice', body: 'Hello' });
+      await flushNotificationHistory();
+      expect(getHistoryData(new Set()).writeError).toBe(true);
+    });
+
+    it('clears writeError after a subsequent successful write', async () => {
+      writeFileMock.mockRejectedValueOnce(new Error('disk full'));
+      addDisplayedNotification({ dbId: '1', sender: 'Alice', body: 'Hello' });
+      await flushNotificationHistory();
+      expect(getHistoryData(new Set()).writeError).toBe(true);
+
+      addDisplayedNotification({ dbId: '2', sender: 'Bob', body: 'World' });
+      await flushNotificationHistory();
+      expect(getHistoryData(new Set()).writeError).toBe(false);
+    });
+  });
+});

--- a/src/main/notificationHistory.ts
+++ b/src/main/notificationHistory.ts
@@ -16,10 +16,13 @@ interface DisplayedEntry {
 export interface HistoryData {
   displayedIds: Set<string>;
   historyOnly: DisplayedEntry[];
+  writeError: boolean;
 }
 
 const MAX_ENTRIES = 200;
 let cache: DisplayedEntry[] | null = null;
+let writeChain: Promise<void> = Promise.resolve();
+let lastWriteError = false;
 
 function getHistoryPath(): string {
   return path.join(app.getPath('userData'), 'displayed-notifications.json');
@@ -37,9 +40,24 @@ function getEntries(): DisplayedEntry[] {
 }
 
 function flushAsync(): void {
-  fs.promises.writeFile(getHistoryPath(), JSON.stringify(cache ?? [])).catch((err) => {
-    console.error('Failed to save notification history:', err);
-  });
+  const snapshot = JSON.stringify(cache ?? []);
+  const target = getHistoryPath();
+  const tmp = `${target}.tmp`;
+
+  writeChain = writeChain
+    .then(() => fs.promises.writeFile(tmp, snapshot))
+    .then(() => fs.promises.rename(tmp, target))
+    .then(() => {
+      lastWriteError = false;
+    })
+    .catch((err) => {
+      lastWriteError = true;
+      console.error('Failed to save notification history:', err);
+    });
+}
+
+export function flushNotificationHistory(): Promise<void> {
+  return writeChain;
 }
 
 export function addDisplayedNotification(data: {
@@ -78,5 +96,12 @@ export function getHistoryData(dbIdSet: Set<string>): HistoryData {
   return {
     displayedIds: new Set(entries.map((e) => e.dbId)),
     historyOnly: entries.filter((e) => !dbIdSet.has(e.dbId)),
+    writeError: lastWriteError,
   };
+}
+
+export function _resetStateForTesting(): void {
+  cache = null;
+  writeChain = Promise.resolve();
+  lastWriteError = false;
 }

--- a/src/main/notificationHistory.ts
+++ b/src/main/notificationHistory.ts
@@ -23,6 +23,11 @@ const MAX_ENTRIES = 200;
 let cache: DisplayedEntry[] | null = null;
 let writeChain: Promise<void> = Promise.resolve();
 let lastWriteError = false;
+let writeErrorCallback: ((hasError: boolean) => void) | null = null;
+
+export function setWriteErrorCallback(cb: (hasError: boolean) => void): void {
+  writeErrorCallback = cb;
+}
 
 function getHistoryPath(): string {
   return path.join(app.getPath('userData'), 'displayed-notifications.json');
@@ -49,9 +54,11 @@ function flushAsync(): void {
     .then(() => fs.promises.rename(tmp, target))
     .then(() => {
       lastWriteError = false;
+      writeErrorCallback?.(false);
     })
     .catch((err) => {
       lastWriteError = true;
+      writeErrorCallback?.(true);
       console.error('Failed to save notification history:', err);
     });
 }
@@ -104,4 +111,5 @@ export function _resetStateForTesting(): void {
   cache = null;
   writeChain = Promise.resolve();
   lastWriteError = false;
+  writeErrorCallback = null;
 }

--- a/src/main/settings.test.ts
+++ b/src/main/settings.test.ts
@@ -17,7 +17,7 @@ vi.mock('node:fs', () => ({
 }));
 
 // Import after mocks are set up.
-import { loadSettings, saveSettings } from './settings';
+import { loadSettings, saveSettings, validateSettings } from './settings';
 
 describe('loadSettings', () => {
   beforeEach(() => {
@@ -86,6 +86,76 @@ describe('saveSettings', () => {
     expect(writeFileSyncMock).toHaveBeenCalledOnce();
     const [, payload] = writeFileSyncMock.mock.calls[0];
     expect(JSON.parse(payload as string)).toEqual({
+      characterFile: 'dance.json',
+      displayDuration: 5000,
+      displayPosition: 'top-right',
+    });
+  });
+
+  it('throws when characterFile is not in the allowed list', () => {
+    expect(() =>
+      saveSettings({
+        characterFile: '../../malicious.json',
+        displayDuration: 5000,
+        displayPosition: 'top-right',
+      }),
+    ).toThrow('Invalid characterFile');
+  });
+});
+
+describe('validateSettings', () => {
+  it('returns valid settings unchanged', () => {
+    expect(
+      validateSettings({
+        characterFile: 'crab.json',
+        displayDuration: 3000,
+        displayPosition: 'bottom-right',
+      }),
+    ).toEqual({
+      characterFile: 'crab.json',
+      displayDuration: 3000,
+      displayPosition: 'bottom-right',
+    });
+  });
+
+  it('falls back to default characterFile for path traversal attempt', () => {
+    expect(validateSettings({ characterFile: '../../etc/passwd' })).toMatchObject({
+      characterFile: 'dance.json',
+    });
+  });
+
+  it('falls back to default characterFile for unknown file', () => {
+    expect(validateSettings({ characterFile: 'custom.json' })).toMatchObject({
+      characterFile: 'dance.json',
+    });
+  });
+
+  it('clamps displayDuration below 1000 to 1000', () => {
+    expect(validateSettings({ displayDuration: 100 })).toMatchObject({
+      displayDuration: 1000,
+    });
+  });
+
+  it('clamps displayDuration above 60000 to 60000', () => {
+    expect(validateSettings({ displayDuration: 999999 })).toMatchObject({
+      displayDuration: 60000,
+    });
+  });
+
+  it('falls back to default displayDuration for non-number', () => {
+    expect(validateSettings({ displayDuration: 'fast' })).toMatchObject({
+      displayDuration: 5000,
+    });
+  });
+
+  it('falls back to default displayPosition for invalid value', () => {
+    expect(validateSettings({ displayPosition: 'center' })).toMatchObject({
+      displayPosition: 'top-right',
+    });
+  });
+
+  it('fills missing fields with defaults', () => {
+    expect(validateSettings({})).toEqual({
       characterFile: 'dance.json',
       displayDuration: 5000,
       displayPosition: 'top-right',

--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -14,20 +14,48 @@ const DEFAULT_SETTINGS: AppSettings = {
   displayPosition: 'top-right',
 };
 
+const ALLOWED_CHARACTER_FILES: readonly string[] = ['dance.json', 'crab.json'];
+const ALLOWED_DISPLAY_POSITIONS: readonly string[] = ['top-right', 'bottom-right'];
+
 function settingsPath(): string {
   return path.join(app.getPath('userData'), 'settings.json');
+}
+
+export function validateSettings(raw: unknown): AppSettings {
+  const r = (raw ?? {}) as Record<string, unknown>;
+
+  const characterFile =
+    typeof r.characterFile === 'string' && ALLOWED_CHARACTER_FILES.includes(r.characterFile)
+      ? r.characterFile
+      : DEFAULT_SETTINGS.characterFile;
+
+  let displayDuration = DEFAULT_SETTINGS.displayDuration;
+  if (typeof r.displayDuration === 'number' && !Number.isNaN(r.displayDuration)) {
+    displayDuration = Math.min(60000, Math.max(1000, r.displayDuration));
+  }
+
+  const displayPosition =
+    typeof r.displayPosition === 'string' && ALLOWED_DISPLAY_POSITIONS.includes(r.displayPosition)
+      ? (r.displayPosition as AppSettings['displayPosition'])
+      : DEFAULT_SETTINGS.displayPosition;
+
+  return { characterFile, displayDuration, displayPosition };
 }
 
 export function loadSettings(): AppSettings {
   try {
     const raw = fs.readFileSync(settingsPath(), 'utf-8');
-    const parsed = JSON.parse(raw);
-    return { ...DEFAULT_SETTINGS, ...parsed };
+    const parsed = JSON.parse(raw) as unknown;
+    return validateSettings(parsed);
   } catch {
     return { ...DEFAULT_SETTINGS };
   }
 }
 
 export function saveSettings(settings: AppSettings): void {
-  fs.writeFileSync(settingsPath(), JSON.stringify(settings, null, 2), 'utf-8');
+  if (!ALLOWED_CHARACTER_FILES.includes(settings.characterFile)) {
+    throw new Error(`Invalid characterFile: ${settings.characterFile}`);
+  }
+  const validated = validateSettings(settings);
+  fs.writeFileSync(settingsPath(), JSON.stringify(validated, null, 2), 'utf-8');
 }

--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -52,10 +52,11 @@ export function loadSettings(): AppSettings {
   }
 }
 
-export function saveSettings(settings: AppSettings): void {
+export function saveSettings(settings: AppSettings): AppSettings {
   if (!ALLOWED_CHARACTER_FILES.includes(settings.characterFile)) {
     throw new Error(`Invalid characterFile: ${settings.characterFile}`);
   }
   const validated = validateSettings(settings);
   fs.writeFileSync(settingsPath(), JSON.stringify(validated, null, 2), 'utf-8');
+  return validated;
 }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -26,4 +26,6 @@ contextBridge.exposeInMainWorld('electronAPI', {
   }) => ipcRenderer.invoke('save-settings', settings),
   getNotificationHistory: () => ipcRenderer.invoke('get-notification-history'),
   onNavigateTab: (callback: (tab: string) => void) => createListener('navigate-tab', callback),
+  onHistoryWriteError: (callback: (hasError: boolean) => void) =>
+    createListener('history-write-error', callback),
 });

--- a/src/renderer/src/SettingsApp.tsx
+++ b/src/renderer/src/SettingsApp.tsx
@@ -34,6 +34,7 @@ export const SettingsApp: React.FC<SettingsAppProps> = ({ initialTab = 'settings
   const [displayDuration, setDisplayDuration] = useState(5);
   const [displayPosition, setDisplayPosition] = useState<'top-right' | 'bottom-right'>('top-right');
   const [saved, setSaved] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
 
   // 通知履歴タブ
   const [historyState, setHistoryState] = useState<HistoryState>({ status: 'idle' });
@@ -68,13 +69,18 @@ export const SettingsApp: React.FC<SettingsAppProps> = ({ initialTab = 'settings
   const isInvalid = displayDuration < MIN_DURATION || displayDuration > MAX_DURATION;
 
   const handleSave = async () => {
-    await window.electronAPI.saveSettings({
-      characterFile,
-      displayDuration: displayDuration * 1000,
-      displayPosition,
-    });
-    setSaved(true);
-    setTimeout(() => setSaved(false), 2000);
+    try {
+      await window.electronAPI.saveSettings({
+        characterFile,
+        displayDuration: displayDuration * 1000,
+        displayPosition,
+      });
+      setSaved(true);
+      setSaveError(null);
+      setTimeout(() => setSaved(false), 2000);
+    } catch (err) {
+      setSaveError(String(err));
+    }
   };
 
   return (
@@ -226,6 +232,10 @@ export const SettingsApp: React.FC<SettingsAppProps> = ({ initialTab = 'settings
 
           {saved && (
             <span style={{ marginLeft: 12, fontSize: 14, color: '#4CAF50' }}>保存しました</span>
+          )}
+
+          {saveError && (
+            <div style={{ marginTop: 8, fontSize: 13, color: '#e53935' }}>{saveError}</div>
           )}
         </div>
       )}

--- a/src/renderer/src/SettingsApp.tsx
+++ b/src/renderer/src/SettingsApp.tsx
@@ -19,7 +19,7 @@ type Tab = 'settings' | 'history';
 type HistoryState =
   | { status: 'idle' }
   | { status: 'loading' }
-  | { status: 'success'; records: LatestNotificationRecord[] }
+  | { status: 'success'; records: LatestNotificationRecord[]; writeError: boolean }
   | { status: 'error'; message: string };
 
 interface SettingsAppProps {
@@ -62,7 +62,9 @@ export const SettingsApp: React.FC<SettingsAppProps> = ({ initialTab = 'settings
     setHistoryState({ status: 'loading' });
     window.electronAPI
       .getNotificationHistory()
-      .then((records) => setHistoryState({ status: 'success', records }))
+      .then(({ records, writeError }) =>
+        setHistoryState({ status: 'success', records, writeError }),
+      )
       .catch((err) => setHistoryState({ status: 'error', message: String(err) }));
   }, [activeTab, refreshKey]);
 
@@ -279,6 +281,21 @@ export const SettingsApp: React.FC<SettingsAppProps> = ({ initialTab = 'settings
           </div>
 
           <div style={{ overflowY: 'auto', flex: 1 }}>
+            {historyState.status === 'success' && historyState.writeError && (
+              <div
+                style={{
+                  padding: '6px 12px',
+                  marginBottom: 8,
+                  borderRadius: 4,
+                  background: '#FFF3E0',
+                  color: '#E65100',
+                  fontSize: 12,
+                }}
+              >
+                履歴の保存に失敗しました
+              </div>
+            )}
+
             {historyState.status === 'loading' && (
               <div style={{ textAlign: 'center', color: '#999', padding: 32, fontSize: 14 }}>
                 読み込み中...

--- a/src/renderer/src/SettingsApp.tsx
+++ b/src/renderer/src/SettingsApp.tsx
@@ -68,6 +68,15 @@ export const SettingsApp: React.FC<SettingsAppProps> = ({ initialTab = 'settings
       .catch((err) => setHistoryState({ status: 'error', message: String(err) }));
   }, [activeTab, refreshKey]);
 
+  // 書き込みエラーのリアルタイム反映
+  useEffect(() => {
+    return window.electronAPI.onHistoryWriteError((hasError) => {
+      setHistoryState((prev) =>
+        prev.status === 'success' ? { ...prev, writeError: hasError } : prev,
+      );
+    });
+  }, []);
+
   const isInvalid = displayDuration < MIN_DURATION || displayDuration > MAX_DURATION;
 
   const handleSave = async () => {
@@ -81,6 +90,7 @@ export const SettingsApp: React.FC<SettingsAppProps> = ({ initialTab = 'settings
       setSaveError(null);
       setTimeout(() => setSaved(false), 2000);
     } catch (err) {
+      setSaved(false);
       setSaveError(String(err));
     }
   };

--- a/src/renderer/src/electron.d.ts
+++ b/src/renderer/src/electron.d.ts
@@ -22,7 +22,10 @@ interface ElectronAPI {
   onSettingsChanged: (callback: (settings: AppSettings) => void) => () => void;
   getSettings: () => Promise<AppSettings>;
   saveSettings: (settings: AppSettings) => Promise<void>;
-  getNotificationHistory: () => Promise<LatestNotificationRecord[]>;
+  getNotificationHistory: () => Promise<{
+    records: LatestNotificationRecord[];
+    writeError: boolean;
+  }>;
   onNavigateTab: (callback: (tab: string) => void) => () => void;
 }
 

--- a/src/renderer/src/electron.d.ts
+++ b/src/renderer/src/electron.d.ts
@@ -27,6 +27,7 @@ interface ElectronAPI {
     writeError: boolean;
   }>;
   onNavigateTab: (callback: (tab: string) => void) => () => void;
+  onHistoryWriteError: (callback: (hasError: boolean) => void) => () => void;
 }
 
 interface Window {


### PR DESCRIPTION
## Summary

- **設定バリデーション追加** (`characterFile` ホワイトリスト、`displayDuration` クランプ 1000–60000ms、`displayPosition` 列挙チェック): パストラバーサルのリスクを排除し、不正値が無検証で保存されるのを防ぐ
- **通知履歴書き込みの直列化 + atomic write**: `writeChain` Promise チェーンでスナップショットを順番通りに書き込み、`tmp → rename` で書き込み途中クラッシュによるファイル破損を防ぐ
- **保存エラーの UI 通知**: 設定保存失敗時は設定タブにエラーメッセージ表示、書き込みエラー時は履歴タブにバナー表示
- **IPC ペイロードのバリデーション漏れ修正**: `save-settings` ハンドラが検証済みの値を `settings-changed` イベントとオーバーレイ位置計算に使用するよう修正 (Codex P2)

Closes #23 (Item 1, Item 2)

## Test Plan

- [ ] `npm test` — 61 テストすべてパス
- [ ] `npm run build` — ビルドエラーなし
- [ ] 設定画面で `characterFile` 以外の値を直接 IPC 送信しても不正値が反映されないことを確認
- [ ] 通知履歴タブで書き込みエラーバナーが表示されることを確認（書き込み失敗を再現した場合）

🤖 Generated with [Claude Code](https://claude.com/claude-code)