### PR TITLE
ci: GitHub Actions で lint と test を自動実行するワークフローを追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Test
+        run: npm test


### PR DESCRIPTION
## Summary

- `.github/workflows/ci.yml` を追加
- `main` への push / PR をトリガーに `ubuntu-latest` で実行
- `npm run lint` と `npm test` を自動検証
- `npm ci --ignore-scripts` で `electron-rebuild` をスキップし、CI に不要なネイティブモジュールビルドを回避

## Test plan

- [ ] PR を push して Actions が緑になることを確認
- [ ] lint エラーを含む PR を作成して Actions が赤くなることを確認

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)