### PR TITLE
fix: 通知履歴機能の回帰不具合を修正 (issue #21)

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -80,6 +80,7 @@ let settingsWindow: BrowserWindow | null = null;
 let tray: Tray | null = null;
 let monitor: BaseNotificationMonitor | null = null;
 
+const MAX_PENDING_NOTIFICATIONS = 50;
 const pendingNotifications = new Map<string, NotificationData>();
 
 const preloadPath = path.join(__dirname, '../preload/index.js');
@@ -287,6 +288,10 @@ app.whenReady().then(() => {
   monitor.on('notification', (notification) => {
     if (notification.dbId) {
       pendingNotifications.set(notification.dbId, notification);
+      if (pendingNotifications.size > MAX_PENDING_NOTIFICATIONS) {
+        const oldest = pendingNotifications.keys().next().value;
+        if (oldest !== undefined) pendingNotifications.delete(oldest);
+      }
     }
     overlayWindow?.webContents.send(IPC_CHANNELS.NOTIFICATION, notification);
   });

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -61,7 +61,12 @@ if (app.isReady()) {
 }
 
 import { IPC_CHANNELS } from '../shared/ipc-channels';
-import type { AppSettings, NotificationHistoryResponse, SettingsTab } from '../shared/types';
+import type {
+  AppSettings,
+  NotificationData,
+  NotificationHistoryResponse,
+  SettingsTab,
+} from '../shared/types';
 import {
   addDisplayedNotification,
   getHistoryData,
@@ -74,6 +79,8 @@ let overlayWindow: BrowserWindow | null = null;
 let settingsWindow: BrowserWindow | null = null;
 let tray: Tray | null = null;
 let monitor: BaseNotificationMonitor | null = null;
+
+const pendingNotifications = new Map<string, NotificationData>();
 
 const preloadPath = path.join(__dirname, '../preload/index.js');
 const rendererHtmlPath = path.join(__dirname, '../renderer/index.html');
@@ -229,6 +236,13 @@ app.whenReady().then(() => {
     const { x, y } = getOverlayPosition(validated);
     overlayWindow?.setPosition(x, y);
   });
+  ipcMain.handle(IPC_CHANNELS.NOTIFICATION_DISPLAYED, (_event, dbId: string) => {
+    const pending = pendingNotifications.get(dbId);
+    if (pending) {
+      addDisplayedNotification(pending);
+      pendingNotifications.delete(dbId);
+    }
+  });
   ipcMain.handle(
     IPC_CHANNELS.GET_NOTIFICATION_HISTORY,
     async (): Promise<NotificationHistoryResponse> => {
@@ -271,8 +285,10 @@ app.whenReady().then(() => {
     });
   });
   monitor.on('notification', (notification) => {
+    if (notification.dbId) {
+      pendingNotifications.set(notification.dbId, notification);
+    }
     overlayWindow?.webContents.send(IPC_CHANNELS.NOTIFICATION, notification);
-    addDisplayedNotification(notification);
   });
   monitor.on('permission-error', async () => {
     if (process.platform === 'darwin') {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -22,6 +22,8 @@ const api: ElectronAPI = {
     createListener(IPC_CHANNELS.NAVIGATE_TAB, callback),
   onHistoryWriteError: (callback: (hasError: boolean) => void) =>
     createListener(IPC_CHANNELS.HISTORY_WRITE_ERROR, callback),
+  notificationDisplayed: (dbId: string) =>
+    ipcRenderer.invoke(IPC_CHANNELS.NOTIFICATION_DISPLAYED, dbId),
 };
 
 contextBridge.exposeInMainWorld('electronAPI', api);

--- a/src/renderer/src/CharacterOverlay.tsx
+++ b/src/renderer/src/CharacterOverlay.tsx
@@ -40,6 +40,10 @@ export const CharacterOverlay: React.FC = () => {
     clearTimeout(displayTimerRef.current);
     clearTimeout(fadeTimerRef.current);
 
+    if (data.dbId) {
+      window.electronAPI.notificationDisplayed(data.dbId).catch(() => {});
+    }
+
     setNotification(data);
     setVisible(true);
     setFading(false);
@@ -62,6 +66,13 @@ export const CharacterOverlay: React.FC = () => {
       clearTimeout(fadeTimerRef.current);
     };
   }, [showNotification]);
+
+  // React commit 後に ack — バッチで描画されなかった通知は ack されない
+  useEffect(() => {
+    if (notification?.dbId) {
+      window.electronAPI.notificationDisplayed(notification.dbId).catch(() => {});
+    }
+  }, [notification]);
 
   if (!visible || !notification) return null;
 

--- a/src/renderer/src/CharacterOverlay.tsx
+++ b/src/renderer/src/CharacterOverlay.tsx
@@ -40,10 +40,6 @@ export const CharacterOverlay: React.FC = () => {
     clearTimeout(displayTimerRef.current);
     clearTimeout(fadeTimerRef.current);
 
-    if (data.dbId) {
-      window.electronAPI.notificationDisplayed(data.dbId).catch(() => {});
-    }
-
     setNotification(data);
     setVisible(true);
     setFading(false);

--- a/src/renderer/src/SettingsApp.tsx
+++ b/src/renderer/src/SettingsApp.tsx
@@ -51,7 +51,10 @@ export const SettingsApp: React.FC<SettingsAppProps> = ({ initialTab = 'settings
   // メインプロセスからのタブ切り替えイベント
   useEffect(() => {
     return window.electronAPI.onNavigateTab((tab) => {
-      if (tab === 'settings' || tab === 'history') setActiveTab(tab);
+      if (tab === 'settings' || tab === 'history') {
+        setActiveTab(tab);
+        if (tab === 'history') setRefreshKey((k) => k + 1);
+      }
     });
   }, []);
 

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -6,4 +6,5 @@ export const IPC_CHANNELS = {
   GET_NOTIFICATION_HISTORY: 'get-notification-history',
   NAVIGATE_TAB: 'navigate-tab',
   HISTORY_WRITE_ERROR: 'history-write-error',
+  NOTIFICATION_DISPLAYED: 'notification-displayed',
 } as const;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -39,4 +39,5 @@ export interface ElectronAPI {
   getNotificationHistory: () => Promise<NotificationHistoryResponse>;
   onNavigateTab: (callback: (tab: SettingsTab) => void) => () => void;
   onHistoryWriteError: (callback: (hasError: boolean) => void) => () => void;
+  notificationDisplayed: (dbId: string) => Promise<void>;
 }


### PR DESCRIPTION
## Summary

- **ack ベースの履歴記録**: 通知がRendererに実際に表示された後にのみ履歴へ記録するよう変更。表示前に記録される誤った「通知済み」フラグを修正
- **pendingNotifications Map**: Mainプロセスが通知をバッファリングし、Rendererからの `notification-displayed` ack 受信後にのみ `addDisplayedNotification` を呼び出す（上限50件）
- **履歴タブの自動リフレッシュ**: トレイメニューから履歴タブを開いた際に履歴を再取得するよう修正
- mainブランチの shared/types・IPC_CHANNELS リファクタリングに対応してrebase済み

## Changes

| ファイル | 変更内容 |
|---|---|
| `src/shared/ipc-channels.ts` | `NOTIFICATION_DISPLAYED` チャンネル追加 |
| `src/shared/types.ts` | `ElectronAPI` に `notificationDisplayed` メソッド追加 |
| `src/main/index.ts` | `pendingNotifications` Map、`NOTIFICATION_DISPLAYED` IPCハンドラ追加 |
| `src/preload/index.ts` | `notificationDisplayed` IPC橋渡しを追加 |
| `src/renderer/src/CharacterOverlay.tsx` | React commit後にack送信するuseEffect追加 |
| `src/renderer/src/SettingsApp.tsx` | 履歴タブ遷移時にrefreshKeyをインクリメント |

## Test plan

- [ ] アプリ起動後に通知が届いた際、履歴に「通知済み」として記録されることを確認
- [ ] トレイ→「最新30件を確認」で履歴タブを開いたとき最新の履歴が表示されることを確認
- [ ] `npm test` (61テスト通過)
- [ ] `npm run lint` (エラーなし)
- [ ] `npm run build` (エラーなし)
- [ ] Codexレビュー: 指摘なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)