### PR TITLE
fix: CharacterOverlay.tsx の useRef に @types/react@19 対応の初期値を追加

### DIFF
--- a/src/renderer/src/CharacterOverlay.tsx
+++ b/src/renderer/src/CharacterOverlay.tsx
@@ -10,8 +10,8 @@ export const CharacterOverlay: React.FC = () => {
   const [lottieData, setLottieData] = useState<object | null>(null);
   const [characterFile, setCharacterFile] = useState('dance.json');
   const displayDurationRef = useRef(5000);
-  const displayTimerRef = useRef<ReturnType<typeof setTimeout>>();
-  const fadeTimerRef = useRef<ReturnType<typeof setTimeout>>();
+  const displayTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+  const fadeTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
 
   const applySettings = useCallback((settings: AppSettings) => {
     setCharacterFile(settings.characterFile);


### PR DESCRIPTION
## Summary
- `@types/react@19` の型変更に対応し、`useRef<T>()` に `undefined` を明示的に渡すよう修正

## Changes
- `src/renderer/src/CharacterOverlay.tsx`: `displayTimerRef`、`fadeTimerRef` の `useRef` 呼び出しに `undefined` を追加

## Test
- `npx tsc --noEmit` でTS型エラーなし

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)