### PR TITLE
fix: Windows PWA アプリ名解決で public suffix を考慮する

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
       "dependencies": {
         "better-sqlite3": "^11.7.0",
         "bplist-parser": "^0.3.2",
-        "lottie-react": "^2.4.1"
+        "lottie-react": "^2.4.1",
+        "tldts": "^7.0.28"
       },
       "devDependencies": {
         "@biomejs/biome": "2.4.10",
@@ -7791,6 +7792,24 @@
       "engines": {
         "node": ">=14.0.0"
       }
+    },
+    "node_modules/tldts": {
+      "version": "7.0.28",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.28.tgz",
+      "integrity": "sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw==",
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.28"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.28",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.28.tgz",
+      "integrity": "sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ==",
+      "license": "MIT"
     },
     "node_modules/tmp": {
       "version": "0.2.5",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,8 @@
   "dependencies": {
     "better-sqlite3": "^11.7.0",
     "bplist-parser": "^0.3.2",
-    "lottie-react": "^2.4.1"
+    "lottie-react": "^2.4.1",
+    "tldts": "^7.0.28"
   },
   "devDependencies": {
     "@biomejs/biome": "2.4.10",

--- a/src/main/appNameResolver.test.ts
+++ b/src/main/appNameResolver.test.ts
@@ -77,10 +77,10 @@ describe('resolveAppNameWin', () => {
     expect(resolveAppNameWin('SomePrefix!https://chat.google.com/messages')).toBe('Google Chat');
   });
 
-  it('returns the second-level domain when host is not a known PWA', () => {
-    expect(resolveAppNameWin('SomePrefix!https://example.co.jp/foo')).toBe('co');
-    // Note: the function takes parts.length - 2, so for example.com it returns "example"
+  it('returns the registrable domain label when host is not a known PWA', () => {
+    expect(resolveAppNameWin('SomePrefix!https://example.co.jp/foo')).toBe('example');
     expect(resolveAppNameWin('SomePrefix!https://example.com/foo')).toBe('example');
+    expect(resolveAppNameWin('SomePrefix!https://www.example.co.jp/foo')).toBe('example');
   });
 
   it('falls back to descriptive segment for package-style ids', () => {

--- a/src/main/appNameResolver.test.ts
+++ b/src/main/appNameResolver.test.ts
@@ -83,6 +83,11 @@ describe('resolveAppNameWin', () => {
     expect(resolveAppNameWin('SomePrefix!https://www.example.co.jp/foo')).toBe('example');
   });
 
+  it('returns the app slug for PWAs hosted on private PSL domains', () => {
+    expect(resolveAppNameWin('SomePrefix!https://my-app.vercel.app/')).toBe('my-app');
+    expect(resolveAppNameWin('SomePrefix!https://foo.github.io/')).toBe('foo');
+  });
+
   it('falls back to descriptive segment for package-style ids', () => {
     // "stable" is non-descriptive, so should pick the next meaningful segment
     expect(resolveAppNameWin('com.example.MyApp.stable')).toBe('MyApp');

--- a/src/main/appNameResolver.ts
+++ b/src/main/appNameResolver.ts
@@ -115,8 +115,8 @@ export function resolveAppNameWin(appId: string): string {
         const url = new URL(afterExcl);
         const pwaName = KNOWN_PWA_HOSTS[url.hostname];
         if (pwaName) return pwaName;
-        const parsed = parseTld(url.hostname);
-        return parsed.domain?.split('.')[0] || url.hostname;
+        const parsed = parseTld(url.hostname, { allowPrivateDomains: true });
+        return parsed.domainWithoutSuffix || url.hostname;
       } catch {
         // malformed URL, fall through
       }

--- a/src/main/appNameResolver.ts
+++ b/src/main/appNameResolver.ts
@@ -1,5 +1,6 @@
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
+import { parse as parseTld } from 'tldts';
 
 const execFileAsync = promisify(execFile);
 
@@ -114,8 +115,8 @@ export function resolveAppNameWin(appId: string): string {
         const url = new URL(afterExcl);
         const pwaName = KNOWN_PWA_HOSTS[url.hostname];
         if (pwaName) return pwaName;
-        const hostParts = url.hostname.split('.');
-        return hostParts.length >= 2 ? hostParts[hostParts.length - 2] : url.hostname;
+        const parsed = parseTld(url.hostname);
+        return parsed.domain?.split('.')[0] || url.hostname;
       } catch {
         // malformed URL, fall through
       }


### PR DESCRIPTION
## Summary
- `tldts` ライブラリを使用して registrable domain を正しく抽出するよう修正
- `.co.jp`、`.co.uk` などのマルチパート TLD でも正しいアプリ名を返す
- `allowPrivateDomains: true` + `domainWithoutSuffix` を使用して、`github.io`、`vercel.app` 等 private PSL エントリのPWAホストでもアプリスラグを正しく返す

## Changes
- `src/main/appNameResolver.ts`: `resolveAppNameWin()` のドメイン抽出ロジックを `tldts` ベースに変更
- `src/main/appNameResolver.test.ts`: `example.co.jp` の期待値を `'co'` → `'example'` に修正、private PSL ドメインのテストケースを追加

## Test
- `npm test` でappNameResolverテスト全通過（62テスト）

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)