### PR TITLE
refactor: 通知履歴の保存件数を200件から30件に統一

### DIFF
--- a/src/main/notificationHistory.ts
+++ b/src/main/notificationHistory.ts
@@ -19,7 +19,7 @@ export interface HistoryData {
   writeError: boolean;
 }
 
-const MAX_ENTRIES = 200;
+const MAX_ENTRIES = 30;
 let cache: DisplayedEntry[] | null = null;
 let writeChain: Promise<void> = Promise.resolve();
 let lastWriteError = false;

--- a/src/renderer/src/SettingsApp.tsx
+++ b/src/renderer/src/SettingsApp.tsx
@@ -305,8 +305,7 @@ export const SettingsApp: React.FC<SettingsAppProps> = ({ initialTab = 'settings
               flexShrink: 0,
             }}
           >
-            通知履歴（最大200件）は送信者・通知本文・アプリ名を含む情報を端末上に平文で保存します。履歴を削除するには、アプリを終了してからアプリのデータフォルダ内の
-            displayed-notifications.json を削除してください。
+            通知履歴（最大30件）は送信者・通知本文・アプリ名を含む情報を端末上に平文で保存します。未通知の情報はOSの通知センターから取得しています。
           </div>
 
           <div style={{ overflowY: 'auto', flex: 1 }}>


### PR DESCRIPTION
## Summary

- 通知履歴の保存上限を200件→30件に変更（UIの表示上限と統一）
- 履歴画面の説明文を更新：削除方法の記載を削除し、通知情報がOSの通知センターから取得されることを明記

## Test plan

- [ ] 通知履歴画面に「最大30件」と表示されることを確認
- [ ] 履歴画面の説明文が更新されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)