### PR TITLE
feat: E2E テスト Phase 2 — 通知オーバーレイの IPC injection テスト

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ dist/
 *.js.map
 .DS_Store
 .worktrees/
+test-results/
+playwright-report/

--- a/src/renderer/src/CharacterOverlay.tsx
+++ b/src/renderer/src/CharacterOverlay.tsx
@@ -56,6 +56,7 @@ export const CharacterOverlay: React.FC = () => {
 
   useEffect(() => {
     const cleanup = window.electronAPI.onNotification(showNotification);
+    document.body.dataset.overlayReady = 'true';
     return () => {
       cleanup();
       clearTimeout(displayTimerRef.current);

--- a/tests/e2e/helpers/launch.ts
+++ b/tests/e2e/helpers/launch.ts
@@ -11,3 +11,19 @@ export async function launchApp(
     env: { ...process.env, E2E_TEST: 'true', ...extraEnv },
   });
 }
+
+export async function sendToOverlay(
+  app: ElectronApplication,
+  channel: string,
+  data: Record<string, unknown>,
+): Promise<void> {
+  await app.evaluate(
+    ({ webContents }, args) => {
+      webContents
+        .getAllWebContents()
+        .find((wc) => !wc.getURL().includes('#'))
+        ?.send(args.channel, args.data);
+    },
+    { channel, data },
+  );
+}

--- a/tests/e2e/notification.spec.ts
+++ b/tests/e2e/notification.spec.ts
@@ -1,0 +1,52 @@
+import { expect, test } from '@playwright/test';
+import { launchApp } from './helpers/launch';
+
+test('overlay displays injected notification', async () => {
+  const app = await launchApp();
+  const overlayWin = await app.firstWindow();
+  await overlayWin.waitForLoadState('domcontentloaded');
+
+  await app.evaluate(({ webContents }) => {
+    const allWC = webContents.getAllWebContents();
+    const overlayWC = allWC.find((wc) => !wc.getURL().includes('#'));
+    overlayWC?.send('notification', {
+      sender: 'テスト送信者',
+      body: 'テスト本文',
+      appName: 'TestApp',
+    });
+  });
+
+  await expect(overlayWin.locator('text=TestApp')).toBeVisible({ timeout: 10_000 });
+  await expect(overlayWin.locator('text=テスト送信者')).toBeVisible();
+  await expect(overlayWin.locator('text=テスト本文')).toBeVisible();
+
+  await app.close();
+});
+
+test('overlay hides after display duration', async () => {
+  const app = await launchApp();
+  const overlayWin = await app.firstWindow();
+  await overlayWin.waitForLoadState('domcontentloaded');
+
+  // Use a short display duration to keep the test fast
+  await app.evaluate(({ webContents }) => {
+    const allWC = webContents.getAllWebContents();
+    const overlayWC = allWC.find((wc) => !wc.getURL().includes('#'));
+    overlayWC?.send('settings-changed', {
+      displayPosition: 'top-right',
+      characterFile: 'dance.json',
+      displayDuration: 1000,
+    });
+    overlayWC?.send('notification', {
+      sender: '消えるテスト',
+      body: '1秒後に消える',
+      appName: 'TestApp',
+    });
+  });
+
+  await expect(overlayWin.locator('text=消えるテスト')).toBeVisible({ timeout: 10_000 });
+  // After display duration (1s) + fade (0.5s), overlay should be gone
+  await expect(overlayWin.locator('text=消えるテスト')).not.toBeVisible({ timeout: 5_000 });
+
+  await app.close();
+});

--- a/tests/e2e/notification.spec.ts
+++ b/tests/e2e/notification.spec.ts
@@ -1,22 +1,18 @@
 import { expect, test } from '@playwright/test';
-import { launchApp } from './helpers/launch';
+import { launchApp, sendToOverlay } from './helpers/launch';
 
 test('overlay displays injected notification', async () => {
   const app = await launchApp();
   const overlayWin = await app.firstWindow();
   await overlayWin.waitForLoadState('domcontentloaded');
 
-  await app.evaluate(({ webContents }) => {
-    const allWC = webContents.getAllWebContents();
-    const overlayWC = allWC.find((wc) => !wc.getURL().includes('#'));
-    overlayWC?.send('notification', {
-      sender: 'テスト送信者',
-      body: 'テスト本文',
-      appName: 'TestApp',
-    });
+  await sendToOverlay(app, 'notification', {
+    sender: 'テスト送信者',
+    body: 'テスト本文',
+    appName: 'TestApp',
   });
 
-  await expect(overlayWin.locator('text=TestApp')).toBeVisible({ timeout: 10_000 });
+  await expect(overlayWin.locator('text=TestApp')).toBeVisible({ timeout: 5_000 });
   await expect(overlayWin.locator('text=テスト送信者')).toBeVisible();
   await expect(overlayWin.locator('text=テスト本文')).toBeVisible();
 
@@ -28,10 +24,10 @@ test('overlay hides after display duration', async () => {
   const overlayWin = await app.firstWindow();
   await overlayWin.waitForLoadState('domcontentloaded');
 
-  // Use a short display duration to keep the test fast
   await app.evaluate(({ webContents }) => {
-    const allWC = webContents.getAllWebContents();
-    const overlayWC = allWC.find((wc) => !wc.getURL().includes('#'));
+    const overlayWC = webContents
+      .getAllWebContents()
+      .find((wc) => !wc.getURL().includes('#'));
     overlayWC?.send('settings-changed', {
       displayPosition: 'top-right',
       characterFile: 'dance.json',
@@ -44,8 +40,7 @@ test('overlay hides after display duration', async () => {
     });
   });
 
-  await expect(overlayWin.locator('text=消えるテスト')).toBeVisible({ timeout: 10_000 });
-  // After display duration (1s) + fade (0.5s), overlay should be gone
+  await expect(overlayWin.locator('text=消えるテスト')).toBeVisible({ timeout: 5_000 });
   await expect(overlayWin.locator('text=消えるテスト')).not.toBeVisible({ timeout: 5_000 });
 
   await app.close();

--- a/tests/e2e/notification.spec.ts
+++ b/tests/e2e/notification.spec.ts
@@ -1,10 +1,13 @@
 import { expect, test } from '@playwright/test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 import { launchApp, sendToOverlay } from './helpers/launch';
 
 test('overlay displays injected notification', async () => {
   const app = await launchApp();
   const overlayWin = await app.firstWindow();
-  await overlayWin.waitForLoadState('domcontentloaded');
+  await overlayWin.waitForFunction(() => (document.body as HTMLElement).dataset.overlayReady === 'true');
 
   await sendToOverlay(app, 'notification', {
     sender: 'テスト送信者',
@@ -20,28 +23,28 @@ test('overlay displays injected notification', async () => {
 });
 
 test('overlay hides after display duration', async () => {
-  const app = await launchApp();
-  const overlayWin = await app.firstWindow();
-  await overlayWin.waitForLoadState('domcontentloaded');
+  const userDataPath = fs.mkdtempSync(path.join(os.tmpdir(), 'mascot-e2e-dur-'));
+  fs.writeFileSync(
+    path.join(userDataPath, 'settings.json'),
+    JSON.stringify({ displayDuration: 1000 }),
+  );
 
-  await app.evaluate(({ webContents }) => {
-    const overlayWC = webContents
-      .getAllWebContents()
-      .find((wc) => !wc.getURL().includes('#'));
-    overlayWC?.send('settings-changed', {
-      displayPosition: 'top-right',
-      characterFile: 'dance.json',
-      displayDuration: 1000,
-    });
-    overlayWC?.send('notification', {
+  try {
+    const app = await launchApp([], { E2E_USERDATA_PATH: userDataPath });
+    const overlayWin = await app.firstWindow();
+    await overlayWin.waitForFunction(() => (document.body as HTMLElement).dataset.overlayReady === 'true');
+
+    await sendToOverlay(app, 'notification', {
       sender: '消えるテスト',
       body: '1秒後に消える',
       appName: 'TestApp',
     });
-  });
 
-  await expect(overlayWin.locator('text=消えるテスト')).toBeVisible({ timeout: 5_000 });
-  await expect(overlayWin.locator('text=消えるテスト')).not.toBeVisible({ timeout: 5_000 });
+    await expect(overlayWin.locator('text=消えるテスト')).toBeVisible({ timeout: 5_000 });
+    await expect(overlayWin.locator('text=消えるテスト')).not.toBeVisible({ timeout: 5_000 });
 
-  await app.close();
+    await app.close();
+  } finally {
+    fs.rmSync(userDataPath, { recursive: true, force: true });
+  }
 });


### PR DESCRIPTION
## Summary

- `tests/e2e/notification.spec.ts` を新規追加。`app.evaluate()` でオーバーレイに直接 IPC 注入し、appName / sender / body の DOM 表示（test 1）と表示時間経過後の非表示（test 2）を検証
- `tests/e2e/helpers/launch.ts` に `sendToOverlay` ヘルパーを追加し、オーバーレイへの IPC 送信ロジックを集約
- `CharacterOverlay.tsx` に `data-overlay-ready` マーカーを追加。`onNotification` リスナー登録後に設定することで、test が useEffect 完了を確実に待てるようにする（Codex P2 対応）

## Codex レビュー対応

- `domcontentloaded` 依存の競合解消 → `waitForFunction(() => dataset.overlayReady === 'true')` に変更
- `settings-changed` 注入 vs `getSettings()` 初期解決の競合解消 → userData に `displayDuration: 1000` を事前設定

## Test plan

- [x] `npm run test:e2e` でローカル全 6 テスト通過 (3.8s)
- [ ] CI (macos-latest) で Phase 1 + Phase 2 テストが通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)