### PR TITLE
fix: 通知履歴リストのReact keyをunixMsから安定したIDに変更

### DIFF
--- a/src/main/notificationHistory.test.ts
+++ b/src/main/notificationHistory.test.ts
@@ -98,6 +98,50 @@ describe('notificationHistory', () => {
     });
   });
 
+  describe('getEntries shape validation', () => {
+    it('falls back to empty array when parsed value is not an array', () => {
+      readFileSyncMock.mockReturnValue('{}');
+      const data = getHistoryData(new Set());
+      expect(data.displayedIds.size).toBe(0);
+      expect(data.historyOnly).toHaveLength(0);
+    });
+
+    it('filters out null elements', () => {
+      readFileSyncMock.mockReturnValue('[null]');
+      const data = getHistoryData(new Set());
+      expect(data.displayedIds.size).toBe(0);
+    });
+
+    it('filters out elements missing dbId', () => {
+      readFileSyncMock.mockReturnValue('[{"sender":"Alice","body":"Hi"}]');
+      const data = getHistoryData(new Set());
+      expect(data.displayedIds.size).toBe(0);
+    });
+
+    it('filters out elements with non-string dbId', () => {
+      readFileSyncMock.mockReturnValue('[{"dbId":123,"sender":"Alice","body":"Hi"}]');
+      const data = getHistoryData(new Set());
+      expect(data.displayedIds.size).toBe(0);
+    });
+
+    it('filters out entries with dbId but missing required numeric unixMs', () => {
+      readFileSyncMock.mockReturnValue(
+        '[{"dbId":"abc","sender":"Alice","body":"Hi","timestamp":"","appName":"","rawId":""}]',
+      );
+      const data = getHistoryData(new Set());
+      expect(data.displayedIds.size).toBe(0);
+    });
+
+    it('preserves valid entries while filtering invalid ones', () => {
+      readFileSyncMock.mockReturnValue(
+        '[{"dbId":"ok","sender":"Alice","body":"Hi","unixMs":0,"timestamp":"","appName":"","rawId":""},null,{"sender":"bad"}]',
+      );
+      const data = getHistoryData(new Set());
+      expect(data.displayedIds.size).toBe(1);
+      expect(data.displayedIds.has('ok')).toBe(true);
+    });
+  });
+
   describe('writeError flag', () => {
     it('sets writeError to true when writeFile throws', async () => {
       writeFileMock.mockRejectedValue(new Error('disk full'));

--- a/src/main/notificationHistory.ts
+++ b/src/main/notificationHistory.ts
@@ -33,10 +33,25 @@ function getHistoryPath(): string {
   return path.join(app.getPath('userData'), 'displayed-notifications.json');
 }
 
+function isValidEntry(e: unknown): e is DisplayedEntry {
+  if (e == null || typeof e !== 'object') return false;
+  const r = e as Record<string, unknown>;
+  return (
+    typeof r.dbId === 'string' &&
+    typeof r.unixMs === 'number' &&
+    typeof r.timestamp === 'string' &&
+    typeof r.sender === 'string' &&
+    typeof r.body === 'string' &&
+    typeof r.appName === 'string' &&
+    typeof r.rawId === 'string'
+  );
+}
+
 function getEntries(): DisplayedEntry[] {
   if (cache === null) {
     try {
-      cache = JSON.parse(fs.readFileSync(getHistoryPath(), 'utf-8')) as DisplayedEntry[];
+      const parsed: unknown = JSON.parse(fs.readFileSync(getHistoryPath(), 'utf-8'));
+      cache = Array.isArray(parsed) ? parsed.filter(isValidEntry) : [];
     } catch {
       cache = [];
     }

--- a/src/renderer/src/SettingsApp.tsx
+++ b/src/renderer/src/SettingsApp.tsx
@@ -361,7 +361,7 @@ export const SettingsApp: React.FC<SettingsAppProps> = ({ initialTab = 'settings
             {historyState.status === 'success' &&
               historyState.records.map((record) => (
                 <div
-                  key={record.unixMs}
+                  key={record.id}
                   style={{
                     padding: '12px 14px',
                     marginBottom: 8,


### PR DESCRIPTION
Closes #42

## 変更内容
- `SettingsApp.tsx`: `key={record.unixMs}` を `key={record.id}`（DB主キー）に変更し、同一ミリ秒内の複数通知でのkey重複を解消
- `notificationHistory.ts`: `isValidEntry` で `dbId` だけでなく `unixMs` など全必須フィールドの型チェックを追加し、不完全なエントリが履歴ビューに渡らないよう強化

## テスト
- npm test: pass (68 tests)
- npm run lint: pass
- npm run build: pass