### PR TITLE
fix: SQLite FDリークを修正し通知本文のログ出力を除去

### DIFF
--- a/src/main/monitors/mac.ts
+++ b/src/main/monitors/mac.ts
@@ -50,18 +50,20 @@ export class MacNotificationMonitor extends BaseNotificationMonitor {
 
     try {
       const db = new Database(this.dbPath, { readonly: true, fileMustExist: true });
-
       const since = this.lastCheckTime / 1000 - MacNotificationMonitor.CORE_DATA_EPOCH_OFFSET;
-      const rows = db
-        .prepare(`
-          SELECT rec.rec_id, rec.data, rec.delivered_date
-          FROM record AS rec
-          WHERE rec.delivered_date > ?
-          ORDER BY rec.delivered_date ASC
-        `)
-        .all(since) as Array<{ rec_id: number; data: Buffer; delivered_date: number }>;
-
-      db.close();
+      let rows: Array<{ rec_id: number; data: Buffer; delivered_date: number }>;
+      try {
+        rows = db
+          .prepare(`
+            SELECT rec.rec_id, rec.data, rec.delivered_date
+            FROM record AS rec
+            WHERE rec.delivered_date > ?
+            ORDER BY rec.delivered_date ASC
+          `)
+          .all(since) as typeof rows;
+      } finally {
+        db.close();
+      }
 
       this.emitStartedOnce();
 
@@ -89,7 +91,6 @@ export class MacNotificationMonitor extends BaseNotificationMonitor {
 
       for (const n of results) {
         if (n === null) continue;
-        console.log('New notification:', n.appName, '-', n.sender, '-', n.body);
         this.emit('notification', n);
       }
 

--- a/src/main/monitors/windows.ts
+++ b/src/main/monitors/windows.ts
@@ -46,25 +46,27 @@ export class WindowsNotificationMonitor extends BaseNotificationMonitor {
   protected async poll(): Promise<void> {
     try {
       const db = new Database(this.dbPath, { readonly: true, fileMustExist: true });
-
-      const rows = db
-        .prepare(
-          `
+      let rows: Array<{
+        Id: number;
+        ArrivalTime: number;
+        Payload: Buffer | string;
+        PrimaryId: string | null;
+      }>;
+      try {
+        rows = db
+          .prepare(
+            `
           SELECT n.Id, n.ArrivalTime, n.Payload, h.PrimaryId
           FROM Notification n
           LEFT JOIN NotificationHandler h ON n.HandlerId = h.RecordId
           WHERE n.ArrivalTime >= ? AND n.Type = 'toast'
           ORDER BY n.ArrivalTime ASC
         `,
-        )
-        .all(this.lastArrivalTime) as Array<{
-        Id: number;
-        ArrivalTime: number;
-        Payload: Buffer | string;
-        PrimaryId: string | null;
-      }>;
-
-      db.close();
+          )
+          .all(this.lastArrivalTime) as typeof rows;
+      } finally {
+        db.close();
+      }
 
       this.emitStartedOnce();
 
@@ -95,7 +97,6 @@ export class WindowsNotificationMonitor extends BaseNotificationMonitor {
 
       for (const n of results) {
         if (n === null) continue;
-        console.log('New notification:', n.appName, `(${n.rawId})`, '-', n.sender, '-', n.body);
         this.emit('notification', n);
       }
 


### PR DESCRIPTION
Closes #39
Closes #40

## 変更内容

### Issue #40: SQLite接続FDリーク修正
- `mac.ts` / `windows.ts`: `poll()` 内の `new Database()` を `try/finally` で囲み、`prepare().all()` が例外を投げても `db.close()` を確実に呼び出す

### Issue #39: 通知本文のログ出力除去
- `mac.ts` / `windows.ts`: `console.log('New notification:', ..., n.sender, n.body)` を削除
- Windowsの `app.log` に通知の送信者・本文が平文で無制限に記録される問題を解消

## テスト
- npm test: 68テストすべてpass
- npm run lint: 指摘なし
- npm run build: pass