### PR TITLE
refactor: displayDuration バリデーション定数を shared/types に統一

### DIFF
--- a/src/main/settings.test.ts
+++ b/src/main/settings.test.ts
@@ -136,9 +136,9 @@ describe('validateSettings', () => {
     });
   });
 
-  it('clamps displayDuration above 60000 to 60000', () => {
+  it('clamps displayDuration above 10000 to 10000', () => {
     expect(validateSettings({ displayDuration: 999999 })).toMatchObject({
-      displayDuration: 60000,
+      displayDuration: 10000,
     });
   });
 

--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -1,8 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { app } from 'electron';
-import type { AppSettings } from '../shared/types';
-import { DURATION_MAX_MS, DURATION_MIN_MS } from '../shared/types';
+import { type AppSettings, DURATION_MAX_MS, DURATION_MIN_MS } from '../shared/types';
 
 const DEFAULT_SETTINGS: AppSettings = {
   characterFile: 'dance.json',

--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { app } from 'electron';
 import type { AppSettings } from '../shared/types';
+import { DURATION_MAX_MS, DURATION_MIN_MS } from '../shared/types';
 
 const DEFAULT_SETTINGS: AppSettings = {
   characterFile: 'dance.json',
@@ -26,7 +27,7 @@ export function validateSettings(raw: unknown): AppSettings {
 
   let displayDuration = DEFAULT_SETTINGS.displayDuration;
   if (typeof r.displayDuration === 'number' && !Number.isNaN(r.displayDuration)) {
-    displayDuration = Math.min(60000, Math.max(1000, r.displayDuration));
+    displayDuration = Math.min(DURATION_MAX_MS, Math.max(DURATION_MIN_MS, r.displayDuration));
   }
 
   const displayPosition =

--- a/src/renderer/src/SettingsApp.tsx
+++ b/src/renderer/src/SettingsApp.tsx
@@ -1,6 +1,12 @@
 import type React from 'react';
 import { useEffect, useState } from 'react';
-import type { AppSettings, LatestNotificationRecord, SettingsTab as Tab } from '../../shared/types';
+import {
+  type AppSettings,
+  DURATION_MAX_MS,
+  DURATION_MIN_MS,
+  type LatestNotificationRecord,
+  type SettingsTab as Tab,
+} from '../../shared/types';
 
 const CHARACTER_OPTIONS = [
   { label: 'ダンス', value: 'dance.json' },
@@ -12,8 +18,8 @@ const POSITION_OPTIONS: { label: string; value: AppSettings['displayPosition'] }
   { label: '右下', value: 'bottom-right' },
 ];
 
-const MIN_DURATION = 1;
-const MAX_DURATION = 10;
+const MIN_DURATION = DURATION_MIN_MS / 1000;
+const MAX_DURATION = DURATION_MAX_MS / 1000;
 
 type HistoryState =
   | { status: 'idle' }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1,3 +1,8 @@
+/** displayDuration の最小値（ミリ秒） */
+export const DURATION_MIN_MS = 1000;
+/** displayDuration の最大値（ミリ秒） */
+export const DURATION_MAX_MS = 10000;
+
 export interface AppSettings {
   characterFile: string;
   displayDuration: number;


### PR DESCRIPTION
## Summary

- `src/shared/types.ts` に `DURATION_MIN_MS = 1000` / `DURATION_MAX_MS = 10000` を定義
- `src/main/settings.ts` のハードコード値（`Math.min(60000, Math.max(1000, ...))`）を定数に置き換え、上限を10秒に統一
- `src/renderer/src/SettingsApp.tsx` のローカル定数 `MIN_DURATION = 1` / `MAX_DURATION = 10` を定数から導出するよう変更（`DURATION_MIN_MS / 1000`）
- `src/main/settings.test.ts` の上限テストケースを新しい上限値（10000ms）に更新

Closes #47

## Test plan

- [ ] `npm test` — 全14テスト通過を確認
- [ ] 設定UIで表示時間の入力範囲が1〜10秒であることを確認
- [ ] 設定ファイルに10秒超の値を直接書いた場合、ロード時に10秒にクランプされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)