### PR TITLE
fix: 通知履歴の一時的I/Oエラー時に空キャッシュで上書きされる問題を修正

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -259,8 +259,8 @@ app.whenReady().then(() => {
   ipcMain.handle(IPC_CHANNELS.NOTIFICATION_DISPLAYED, (_event, dbId: string) => {
     const pending = pendingNotifications.get(dbId);
     if (pending) {
-      addDisplayedNotification(pending);
-      pendingNotifications.delete(dbId);
+      const recorded = addDisplayedNotification(pending);
+      if (recorded) pendingNotifications.delete(dbId);
     }
   });
   ipcMain.handle(

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -259,8 +259,16 @@ app.whenReady().then(() => {
   ipcMain.handle(IPC_CHANNELS.NOTIFICATION_DISPLAYED, (_event, dbId: string) => {
     const pending = pendingNotifications.get(dbId);
     if (pending) {
-      const recorded = addDisplayedNotification(pending);
-      if (recorded) pendingNotifications.delete(dbId);
+      if (addDisplayedNotification(pending)) {
+        pendingNotifications.delete(dbId);
+      } else {
+        // Transient read failure: retry once after a short delay so the entry
+        // is recorded after the filesystem recovers.
+        setTimeout(() => {
+          const still = pendingNotifications.get(dbId);
+          if (still && addDisplayedNotification(still)) pendingNotifications.delete(dbId);
+        }, 5000);
+      }
     }
   });
   ipcMain.handle(

--- a/src/main/notificationHistory.test.ts
+++ b/src/main/notificationHistory.test.ts
@@ -161,4 +161,42 @@ describe('notificationHistory', () => {
       expect(getHistoryData(new Set()).writeError).toBe(false);
     });
   });
+
+  describe('transient read error guard', () => {
+    it('returns false and does not write when readFileSync throws a non-ENOENT error', async () => {
+      readFileSyncMock.mockImplementation(() => {
+        throw Object.assign(new Error('EPERM'), { code: 'EPERM' });
+      });
+      const recorded = addDisplayedNotification({ dbId: '1', sender: 'Alice', body: 'Hello' });
+      await flushNotificationHistory();
+      expect(recorded).toBe(false);
+      expect(writeFileMock).not.toHaveBeenCalled();
+    });
+
+    it('self-heals and records after a transient read error resolves', async () => {
+      readFileSyncMock
+        .mockImplementationOnce(() => {
+          throw Object.assign(new Error('EPERM'), { code: 'EPERM' });
+        })
+        .mockImplementation(() => {
+          throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+        });
+      const first = addDisplayedNotification({ dbId: '1', sender: 'Alice', body: 'Hello' });
+      expect(first).toBe(false);
+
+      // cache is still null after transient error, so next call retries the read
+      const second = addDisplayedNotification({ dbId: '1', sender: 'Alice', body: 'Hello' });
+      await flushNotificationHistory();
+      expect(second).toBe(true);
+      expect(writeFileMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('self-heals when history file contains malformed JSON', async () => {
+      readFileSyncMock.mockReturnValue('{not valid json');
+      const recorded = addDisplayedNotification({ dbId: '1', sender: 'Alice', body: 'Hello' });
+      await flushNotificationHistory();
+      expect(recorded).toBe(true);
+      expect(writeFileMock).toHaveBeenCalledTimes(1);
+    });
+  });
 });

--- a/src/main/notificationHistory.ts
+++ b/src/main/notificationHistory.ts
@@ -102,8 +102,6 @@ export function addDisplayedNotification(data: {
 }): void {
   if (!data.dbId) return;
 
-  // If reading the history file failed with a non-ENOENT error, skip mutation
-  // to avoid flushing an empty cache over existing on-disk history.
   const entries = getEntries();
   if (loadFailed) return;
 

--- a/src/main/notificationHistory.ts
+++ b/src/main/notificationHistory.ts
@@ -21,6 +21,7 @@ export interface HistoryData {
 
 const MAX_ENTRIES = 30;
 let cache: DisplayedEntry[] | null = null;
+let loadFailed = false;
 let writeChain: Promise<void> = Promise.resolve();
 let lastWriteError = false;
 let writeErrorCallback: ((hasError: boolean) => void) | null = null;
@@ -52,11 +53,20 @@ function getEntries(): DisplayedEntry[] {
     try {
       const parsed: unknown = JSON.parse(fs.readFileSync(getHistoryPath(), 'utf-8'));
       cache = Array.isArray(parsed) ? parsed.filter(isValidEntry) : [];
-    } catch {
-      cache = [];
+      loadFailed = false;
+    } catch (err: unknown) {
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+        cache = [];
+        loadFailed = false;
+      } else {
+        // Transient I/O error: keep cache null so next read retries,
+        // and set loadFailed to prevent flushing over existing on-disk data.
+        console.error('Failed to read notification history:', err);
+        loadFailed = true;
+      }
     }
   }
-  return cache;
+  return cache ?? [];
 }
 
 function flushAsync(): void {
@@ -92,7 +102,11 @@ export function addDisplayedNotification(data: {
 }): void {
   if (!data.dbId) return;
 
+  // If reading the history file failed with a non-ENOENT error, skip mutation
+  // to avoid flushing an empty cache over existing on-disk history.
   const entries = getEntries();
+  if (loadFailed) return;
+
   if (entries.some((e) => e.dbId === data.dbId)) return;
 
   const unixMs = data.unixMs ?? Date.now();
@@ -124,6 +138,7 @@ export function getHistoryData(dbIdSet: Set<string>): HistoryData {
 
 export function _resetStateForTesting(): void {
   cache = null;
+  loadFailed = false;
   writeChain = Promise.resolve();
   lastWriteError = false;
   writeErrorCallback = null;

--- a/src/main/notificationHistory.ts
+++ b/src/main/notificationHistory.ts
@@ -50,10 +50,9 @@ function isValidEntry(e: unknown): e is DisplayedEntry {
 
 function getEntries(): DisplayedEntry[] {
   if (cache === null) {
+    let raw: string;
     try {
-      const parsed: unknown = JSON.parse(fs.readFileSync(getHistoryPath(), 'utf-8'));
-      cache = Array.isArray(parsed) ? parsed.filter(isValidEntry) : [];
-      loadFailed = false;
+      raw = fs.readFileSync(getHistoryPath(), 'utf-8');
     } catch (err: unknown) {
       if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
         cache = [];
@@ -64,6 +63,17 @@ function getEntries(): DisplayedEntry[] {
         console.error('Failed to read notification history:', err);
         loadFailed = true;
       }
+      return cache ?? [];
+    }
+    try {
+      const parsed: unknown = JSON.parse(raw);
+      cache = Array.isArray(parsed) ? parsed.filter(isValidEntry) : [];
+      loadFailed = false;
+    } catch (err) {
+      // Malformed JSON: reset to empty so history recording can self-heal.
+      console.error('Malformed notification history JSON, resetting:', err);
+      cache = [];
+      loadFailed = false;
     }
   }
   return cache ?? [];
@@ -99,13 +109,13 @@ export function addDisplayedNotification(data: {
   body: string;
   appName?: string;
   rawId?: string;
-}): void {
-  if (!data.dbId) return;
+}): boolean {
+  if (!data.dbId) return false;
 
   const entries = getEntries();
-  if (loadFailed) return;
+  if (loadFailed) return false;
 
-  if (entries.some((e) => e.dbId === data.dbId)) return;
+  if (entries.some((e) => e.dbId === data.dbId)) return true;
 
   const unixMs = data.unixMs ?? Date.now();
   entries.unshift({
@@ -123,6 +133,7 @@ export function addDisplayedNotification(data: {
   }
 
   flushAsync();
+  return true;
 }
 
 export function getHistoryData(dbIdSet: Set<string>): HistoryData {


### PR DESCRIPTION
## Summary

- `getEntries()` でファイル読み込みとJSONパースを分離し、malformed JSON時は自己修復（空配列リセット）するよう変更
- `addDisplayedNotification()` の戻り値を `boolean` に変更し、一時的なI/Oエラー時に `false` を返すことで呼び出し元がリトライ可能に
- `NOTIFICATION_DISPLAYED` ハンドラで記録成功時のみ `pendingNotifications` から削除し、失敗時は5秒後にリトライ
- 3つの回帰テストを追加（EPERM リトライ、transient error 後の自己修復、malformed JSON 回復）

Closes #48

## Test plan

- [ ] `npm test -- src/main/notificationHistory.test.ts` — 15 tests passing
- [ ] `npm run lint` — no issues
- ENOENT: 既存の動作通り空配列で初期化
- EPERM/EBUSY 等の一時的エラー: `loadFailed=true`、`addDisplayedNotification` は `false` を返し5秒後リトライ
- Malformed JSON: 空配列にリセットして自己修復
- 正常系: 変更なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)