### PR TITLE
fix: loadSettingsがENOENT以外のエラーをサイレントにデフォルト復帰する問題を修正

### DIFF
--- a/src/main/settings.test.ts
+++ b/src/main/settings.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('electron', () => ({
   app: {
@@ -20,9 +20,16 @@ vi.mock('node:fs', () => ({
 import { loadSettings, saveSettings, validateSettings } from './settings';
 
 describe('loadSettings', () => {
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
   beforeEach(() => {
     readFileSyncMock.mockReset();
     writeFileSyncMock.mockReset();
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
   });
 
   it('returns defaults when the file does not exist', () => {
@@ -38,6 +45,16 @@ describe('loadSettings', () => {
     });
   });
 
+  it('does not log when the file does not exist (ENOENT is normal first-run)', () => {
+    readFileSyncMock.mockImplementation(() => {
+      const err = new Error('ENOENT');
+      (err as NodeJS.ErrnoException).code = 'ENOENT';
+      throw err;
+    });
+    loadSettings();
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+  });
+
   it('returns defaults when the file contains invalid JSON', () => {
     readFileSyncMock.mockReturnValue('not-json');
     expect(loadSettings()).toEqual({
@@ -45,6 +62,28 @@ describe('loadSettings', () => {
       displayDuration: 5000,
       displayPosition: 'top-right',
     });
+  });
+
+  it('logs an error when the file contains invalid JSON', () => {
+    readFileSyncMock.mockReturnValue('not-json');
+    loadSettings();
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      'Failed to load settings:',
+      expect.any(SyntaxError),
+    );
+  });
+
+  it('logs an error on non-ENOENT I/O errors', () => {
+    readFileSyncMock.mockImplementation(() => {
+      const err = new Error('EACCES');
+      (err as NodeJS.ErrnoException).code = 'EACCES';
+      throw err;
+    });
+    loadSettings();
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      'Failed to load settings:',
+      expect.objectContaining({ message: 'EACCES' }),
+    );
   });
 
   it('merges defaults with the stored values', () => {

--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -40,9 +40,11 @@ export function validateSettings(raw: unknown): AppSettings {
 export function loadSettings(): AppSettings {
   try {
     const raw = fs.readFileSync(settingsPath(), 'utf-8');
-    const parsed = JSON.parse(raw) as unknown;
-    return validateSettings(parsed);
-  } catch {
+    return validateSettings(JSON.parse(raw) as unknown);
+  } catch (err: unknown) {
+    if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
+      console.error('Failed to load settings:', err);
+    }
     return { ...DEFAULT_SETTINGS };
   }
 }


### PR DESCRIPTION
## Summary

- `loadSettings` で `ENOENT`（初回起動・ファイル未存在）は正常ケースとしてサイレントにデフォルト設定を返す
- JSON破損・権限エラー（`EACCES`）などENOENT以外のエラーは `console.error` でログ出力するよう修正
- 既存の「全エラーをサイレント」動作を廃止し、問題の早期発見を可能にする

## Changes

- `src/main/settings.ts`: `loadSettings` の catch 節で `err.code !== 'ENOENT'` を判定し、それ以外は `console.error` を呼ぶ
- `src/main/settings.test.ts`: ENOENT時に非ログ・SyntaxError時にログ・EACCES時にログの3テストケースを追加

Closes #49