### PR TITLE
feat: ディスプレイ変更イベントでオーバーレイ位置を再計算する

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -127,6 +127,13 @@ function getOverlayPosition(settings: AppSettings): { x: number; y: number } {
   return { x, y };
 }
 
+function updateOverlayPosition(): void {
+  if (!overlayWindow || overlayWindow.isDestroyed()) return;
+  const settings = loadSettings();
+  const { x, y } = getOverlayPosition(settings);
+  overlayWindow.setPosition(x, y);
+}
+
 function createOverlayWindow(): BrowserWindow {
   const settings = loadSettings();
   const { x, y } = getOverlayPosition(settings);
@@ -245,6 +252,10 @@ app.whenReady().then(() => {
   overlayWindow = createOverlayWindow();
   createTray();
 
+  for (const event of ['display-added', 'display-removed', 'display-metrics-changed'] as const) {
+    screen.on(event, updateOverlayPosition);
+  }
+
   setWriteErrorCallback((hasError) => {
     settingsWindow?.webContents.send(IPC_CHANNELS.HISTORY_WRITE_ERROR, hasError);
   });
@@ -253,8 +264,7 @@ app.whenReady().then(() => {
   ipcMain.handle(IPC_CHANNELS.SAVE_SETTINGS, (_event, settings: AppSettings) => {
     const validated = saveSettings(settings);
     overlayWindow?.webContents.send(IPC_CHANNELS.SETTINGS_CHANGED, validated);
-    const { x, y } = getOverlayPosition(validated);
-    overlayWindow?.setPosition(x, y);
+    updateOverlayPosition();
   });
   ipcMain.handle(IPC_CHANNELS.NOTIFICATION_DISPLAYED, (_event, dbId: string) => {
     const pending = pendingNotifications.get(dbId);
@@ -384,6 +394,9 @@ app.on('window-all-closed', () => {
 });
 
 app.on('before-quit', () => {
+  for (const event of ['display-added', 'display-removed', 'display-metrics-changed'] as const) {
+    screen.removeListener(event, updateOverlayPosition);
+  }
   monitor?.stop();
   logStream?.end();
 });

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -116,6 +116,7 @@ function loadSettingsPage(win: BrowserWindow, hash?: string): void {
 const OVERLAY_WIN_WIDTH = 300;
 const OVERLAY_WIN_HEIGHT = 280;
 const OVERLAY_MARGIN = 16;
+const DISPLAY_EVENTS = ['display-added', 'display-removed', 'display-metrics-changed'] as const;
 
 function getOverlayPosition(settings: AppSettings): { x: number; y: number } {
   const { x: workAreaX, y: workAreaY, width, height } = screen.getPrimaryDisplay().workArea;
@@ -252,7 +253,7 @@ app.whenReady().then(() => {
   overlayWindow = createOverlayWindow();
   createTray();
 
-  for (const event of ['display-added', 'display-removed', 'display-metrics-changed'] as const) {
+  for (const event of DISPLAY_EVENTS) {
     screen.on(event, updateOverlayPosition);
   }
 
@@ -394,7 +395,7 @@ app.on('window-all-closed', () => {
 });
 
 app.on('before-quit', () => {
-  for (const event of ['display-added', 'display-removed', 'display-metrics-changed'] as const) {
+  for (const event of DISPLAY_EVENTS) {
     screen.removeListener(event, updateOverlayPosition);
   }
   monitor?.stop();


### PR DESCRIPTION
## 概要

- `display-added` / `display-removed` / `display-metrics-changed` イベントをサブスクライブし、外部モニターの接続・切断・解像度変更・Dock位置変更時にオーバーレイウィンドウの位置を自動再計算する
- `updateOverlayPosition()` ヘルパーを抽出し、起動時・設定保存時・ディスプレイイベント時の3箇所で共通化（DRY）
- `DISPLAY_EVENTS` 定数を定義してリスナー登録・解除の両箇所で共有
- `before-quit` 時にリスナーを明示的に解除してクリーンアップ

Closes #50

## 変更内容

- `src/main/index.ts`: `updateOverlayPosition()` 追加、`DISPLAY_EVENTS` 定数、`screen.on()` 登録、`before-quit` での `screen.removeListener()` 追加